### PR TITLE
[feat] 일반일정,경로일정 화면제작

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.pace"
-        minSdk = 33
+        minSdk = 31
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"
@@ -27,6 +27,7 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
@@ -45,7 +46,13 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.ui.graphics)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    //캘린더뷰 라이브러리
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    implementation("com.kizitonwose.calendar:view:2.5.1")
+    implementation("com.kizitonwose.calendar:core:2.5.1")
 }

--- a/app/src/main/java/com/example/pace/ui/add_schedule/AddScheduleActivity.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/AddScheduleActivity.kt
@@ -1,4 +1,67 @@
 package com.example.pace.ui.add_schedule
 
-class AddScheduleActivity {
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
+import com.example.pace.databinding.ActivityAddScheduleBinding
+
+class AddScheduleActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityAddScheduleBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // 1. 뷰 바인딩 연결
+        binding = ActivityAddScheduleBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        // 2. ViewPager2 어댑터 연결
+        val pagerAdapter = object : FragmentStateAdapter(this) {
+            override fun getItemCount(): Int = 2
+            override fun createFragment(position: Int): Fragment {
+                return when (position) {
+                    0 -> GeneralScheduleFragment() // 일반 일정
+                    else -> RouteScheduleFragment() // 경로 일정
+                }
+            }
+        }
+        binding.viewPager.adapter = pagerAdapter
+
+        // 3. 탭 클릭 리스너 (이미지의 탭 셀렉터 버튼들)
+        binding.btnTabGeneral.setOnClickListener {
+            binding.viewPager.currentItem = 0
+        }
+        binding.btnTabRoute.setOnClickListener {
+            binding.viewPager.currentItem = 1
+        }
+
+        // 4. 페이지가 변경될 때 탭 디자인(글자색, 배경) 업데이트
+        binding.viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                updateTabUI(position)
+            }
+        })
+    }
+
+    private fun updateTabUI(position: Int) {
+        if (position == 0) {
+            binding.btnTabGeneral.setTextColor(Color.BLACK)
+            binding.btnTabGeneral.setTypeface(null, Typeface.BOLD)
+            // 여기에 '일반 일정' 버튼 배경 변경 코드 추가
+
+            binding.btnTabRoute.setTextColor(Color.GRAY)
+            binding.btnTabRoute.setTypeface(null, Typeface.NORMAL)
+        } else {
+            binding.btnTabRoute.setTextColor(Color.BLACK)
+            binding.btnTabRoute.setTypeface(null, Typeface.BOLD)
+            // 여기에 '경로 일정' 버튼 배경 변경 코드 추가
+
+            binding.btnTabGeneral.setTextColor(Color.GRAY)
+            binding.btnTabGeneral.setTypeface(null, Typeface.NORMAL)
+        }
+    }
 }

--- a/app/src/main/java/com/example/pace/ui/add_schedule/GerneralScheduleFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/GerneralScheduleFragment.kt
@@ -1,0 +1,183 @@
+package com.example.pace.ui.add_schedule
+
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.NumberPicker
+import androidx.fragment.app.Fragment
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.color.colorChooser
+import com.example.pace.databinding.FragmentGeneralScheduleBinding // 바인딩 클래스 임포트
+
+class GeneralScheduleFragment : Fragment() {
+
+    // 1. 메모리 누수 방지를 위한 바인딩 객체 선언
+    private var _binding: FragmentGeneralScheduleBinding? = null
+    private val binding get() = _binding!!
+
+    private var isEditingStartTime: Boolean = true
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        // fragment_general_schedule.xml 레이아웃 연결
+        _binding = FragmentGeneralScheduleBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 초기 설정: NumberPicker 범위 지정 등 (필수)
+        initTimePickers()
+
+        // 1. 시작 날짜/시간 클릭 리스너
+        binding.btnStartDate.setOnClickListener { showCalendar() }
+        binding.tvStartTime.setOnClickListener {
+            isEditingStartTime = true // 시작 시간 수정 모드
+            showTimePicker()
+        }
+
+        // 2. 종료 날짜/시간 클릭 리스너 (추가)
+        binding.btnEndDate.setOnClickListener { showCalendar() }
+        binding.tvEndTime.setOnClickListener {
+            isEditingStartTime = false // 종료 시간 수정 모드
+            showTimePicker()
+        }
+
+        // 3. 컬러 피커(view_color_dot) 클릭 리스너 설정
+        binding.viewColorDot.setOnClickListener {
+            openColorPicker()
+        }
+
+        // 1. 메인 동그라미 클릭 시 색상 판넬 토글
+        binding.viewColorDot.setOnClickListener {
+            if (binding.layoutColorSelector.visibility == View.GONE) {
+                binding.layoutColorSelector.visibility = View.VISIBLE
+                // 다른 피커(달력, 타임피커)는 닫아주는 것이 깔끔함
+                binding.calendarPicker.visibility = View.GONE
+                binding.timePickerContainer.visibility = View.GONE
+            } else {
+                binding.layoutColorSelector.visibility = View.GONE
+            }
+        }
+
+        // 2. 개별 색상 클릭 시 처리 (예시: 빨강, 핑크)
+        binding.colorRed.setOnClickListener { changeSelectedColor("#F44336") }
+        binding.colorPink.setOnClickListener { changeSelectedColor("#E91E63") }
+        binding.colorGreen.setOnClickListener { changeSelectedColor("#4CAF50") }
+
+
+    }
+
+    private fun changeSelectedColor(colorStr: String) {
+        val color = Color.parseColor(colorStr)
+        // 메인 동그라미 색상 변경
+        binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(color)
+        // 선택 후 판넬 닫기 (선택 사항)
+        binding.layoutColorSelector.visibility = View.GONE
+    }
+
+    private fun openColorPicker() {
+        val colors = intArrayOf(
+            Color.parseColor("#F44336"), Color.parseColor("#E91E63"),
+            Color.parseColor("#FF9800"), Color.parseColor("#4CAF50"),
+            Color.parseColor("#2196F3"), Color.parseColor("#9C27B0")
+        )
+
+        MaterialDialog(requireContext()).show {
+            title(text = "색상 선택")
+            colorChooser(colors) { _, color ->
+                // 선택한 색상을 view_color_dot에 즉시 적용
+                binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(color)
+            }
+            positiveButton(text = "확인")
+        }
+    }
+
+    private fun initTimePickers() {
+        // 시간 설정 (00 ~ 23)
+        binding.pickerHour.apply {
+            minValue = 0
+            maxValue = 23
+
+            setFormatter { String.format("%02d", it) }
+            // 순환 모드 (23시 다음 00시)
+            wrapSelectorWheel = true
+        }
+
+        // 분 설정 (00 ~ 59)
+        binding.pickerMinute.apply {
+            minValue = 0
+            maxValue = 59
+            setFormatter { String.format("%02d", it) }
+            wrapSelectorWheel = true
+        }
+
+        val timeChangeListener = NumberPicker.OnValueChangeListener { _, _, _ ->
+            val hour = String.format("%02d", binding.pickerHour.value)
+            val minute = String.format("%02d", binding.pickerMinute.value)
+            val formattedTime = "$hour:$minute"
+
+            if (isEditingStartTime) {
+                // 시작 시간 업데이트
+                binding.tvStartTime.text = formattedTime
+                binding.tvStartTime.setTextColor(Color.parseColor("#8BC34A"))
+            } else {
+                // 종료 시간 업데이트 (추가)
+                binding.tvEndTime.text = formattedTime
+                binding.tvEndTime.setTextColor(Color.parseColor("#8BC34A"))
+            }
+        }
+
+        binding.pickerHour.setOnValueChangedListener(timeChangeListener)
+        binding.pickerMinute.setOnValueChangedListener(timeChangeListener)
+    }
+
+
+    private fun showCalendar() {
+        binding.calendarPicker.visibility = View.VISIBLE
+        binding.timePickerContainer.visibility = View.GONE
+    }
+
+    private fun showTimePicker() {
+        binding.timePickerContainer.visibility = View.VISIBLE
+        binding.calendarPicker.visibility = View.GONE
+
+        // 현재 텍스트 뷰에 있는 시간 정보를 안전하게 가져오기
+        val timeText = if (isEditingStartTime) {
+            binding.tvStartTime.text.toString()
+        } else {
+            binding.tvEndTime.text.toString()
+        }
+
+        try {
+            // "10:00" 형태를 ":" 기준으로 분리
+            val parts = timeText.split(":")
+            if (parts.size == 2) {
+                val h = parts[0].trim().toInt()
+                val m = parts[1].trim().toInt()
+
+                // NumberPicker 범위(0~23, 0~59)를 벗어나지 않는지 체크 후 세팅
+                binding.pickerHour.value = if (h in 0..23) h else 0
+                binding.pickerMinute.value = if (m in 0..59) m else 0
+            }
+        } catch (e: Exception) {
+            // 형식 에러가 나면 기본값(현재 시간 등)으로 세팅하여 튕김 방지
+            binding.pickerHour.value = 10
+            binding.pickerMinute.value = 0
+        }
+    }
+
+    // 4. 프래그먼트 파괴 시 바인딩 해제
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
@@ -1,0 +1,157 @@
+package com.example.pace.ui.add_schedule
+
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.NumberPicker
+import androidx.fragment.app.Fragment
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.color.colorChooser
+import com.example.pace.databinding.FragmentRouteScheduleBinding// 바인딩 클래스 임포트
+
+class RouteScheduleFragment : Fragment() {
+
+    // 1. 메모리 누수 방지를 위한 바인딩 객체 선언
+    private var _binding: FragmentRouteScheduleBinding? = null
+    private val binding get() = _binding!!
+
+    private var isEditingStartTime: Boolean = true
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        // fragment_route_schedule.xml 레이아웃 연결
+        _binding = FragmentRouteScheduleBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 초기 설정: NumberPicker 범위 지정 등 (필수)
+        initTimePickers()
+
+        // 1. 시작 날짜/시간 클릭 리스너
+        binding.btnStartDate.setOnClickListener { showCalendar() }
+        binding.tvStartTime.setOnClickListener {
+            isEditingStartTime = true // 시작 시간 수정 모드
+            showTimePicker()
+        }
+
+        // 2. 종료 날짜/시간 클릭 리스너 (추가)
+        binding.btnEndDate.setOnClickListener { showCalendar() }
+        binding.tvEndTime.setOnClickListener {
+            isEditingStartTime = false // 종료 시간 수정 모드
+            showTimePicker()
+        }
+
+        // 3. 컬러 피커(view_color_dot) 클릭 리스너 설정
+        binding.viewColorDot.setOnClickListener {
+            openColorPicker()
+        }
+
+    }
+
+    private fun openColorPicker() {
+        val colors = intArrayOf(
+            Color.parseColor("#F44336"), Color.parseColor("#E91E63"),
+            Color.parseColor("#FF9800"), Color.parseColor("#4CAF50"),
+            Color.parseColor("#2196F3"), Color.parseColor("#9C27B0")
+        )
+
+        MaterialDialog(requireContext()).show {
+            title(text = "색상 선택")
+            colorChooser(colors) { _, color ->
+                // 선택한 색상을 view_color_dot에 즉시 적용
+                binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(color)
+            }
+            positiveButton(text = "확인")
+        }
+    }
+
+    private fun initTimePickers() {
+        // 시간 설정 (00 ~ 23)
+        binding.pickerHour.apply {
+            minValue = 0
+            maxValue = 23
+
+            setFormatter { String.format("%02d", it) }
+            // 순환 모드 (23시 다음 00시)
+            wrapSelectorWheel = true
+        }
+
+        // 분 설정 (00 ~ 59)
+        binding.pickerMinute.apply {
+            minValue = 0
+            maxValue = 59
+            setFormatter { String.format("%02d", it) }
+            wrapSelectorWheel = true
+        }
+
+        val timeChangeListener = NumberPicker.OnValueChangeListener { _, _, _ ->
+            val hour = String.format("%02d", binding.pickerHour.value)
+            val minute = String.format("%02d", binding.pickerMinute.value)
+            val formattedTime = "$hour:$minute"
+
+            if (isEditingStartTime) {
+                // 시작 시간 업데이트
+                binding.tvStartTime.text = formattedTime
+                binding.tvStartTime.setTextColor(Color.parseColor("#8BC34A"))
+            } else {
+                // 종료 시간 업데이트 (추가)
+                binding.tvEndTime.text = formattedTime
+                binding.tvEndTime.setTextColor(Color.parseColor("#8BC34A"))
+            }
+        }
+
+        binding.pickerHour.setOnValueChangedListener(timeChangeListener)
+        binding.pickerMinute.setOnValueChangedListener(timeChangeListener)
+    }
+
+
+    private fun showCalendar() {
+        binding.calendarPicker.visibility = View.VISIBLE
+        binding.timePickerContainer.visibility = View.GONE
+    }
+
+    private fun showTimePicker() {
+        binding.timePickerContainer.visibility = View.VISIBLE
+        binding.calendarPicker.visibility = View.GONE
+
+        // 현재 텍스트 뷰에 있는 시간 정보를 안전하게 가져오기
+        val timeText = if (isEditingStartTime) {
+            binding.tvStartTime.text.toString()
+        } else {
+            binding.tvEndTime.text.toString()
+        }
+
+        try {
+            // "10:00" 형태를 ":" 기준으로 분리
+            val parts = timeText.split(":")
+            if (parts.size == 2) {
+                val h = parts[0].trim().toInt()
+                val m = parts[1].trim().toInt()
+
+                // NumberPicker 범위(0~23, 0~59)를 벗어나지 않는지 체크 후 세팅
+                binding.pickerHour.value = if (h in 0..23) h else 0
+                binding.pickerMinute.value = if (m in 0..59) m else 0
+            }
+        } catch (e: Exception) {
+            // 형식 에러가 나면 기본값(현재 시간 등)으로 세팅하여 튕김 방지
+            binding.pickerHour.value = 10
+            binding.pickerMinute.value = 0
+        }
+    }
+
+    // 4. 프래그먼트 파괴 시 바인딩 해제
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/drawable/box_addschedule_selector.xml
+++ b/app/src/main/res/drawable/box_addschedule_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="4dp"/>
+    <solid android:color="@color/gray_200"/>
+        </shape>

--- a/app/src/main/res/drawable/circle_schedulecolor.xml
+++ b/app/src/main/res/drawable/circle_schedulecolor.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/black" /> </shape>

--- a/app/src/main/res/layout/activity_add_schedule.xml
+++ b/app/src/main/res/layout/activity_add_schedule.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:background="#F5F5F5">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/addsche_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="새로운 일정 추가"
+                android:textAppearance="@style/TextAppearance.App.HeadlineSm"
+                android:textStyle="bold" />
+        </androidx.appcompat.widget.Toolbar>
+
+        <LinearLayout
+            android:id="@+id/layout_tab_selector"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_addschedule_selector"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/btn_tab_general"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@drawable/box_schedule"
+                android:gravity="center"
+                android:text="일반 일정"
+                android:textColor="@color/black"
+                android:textAppearance="@style/TextAppearance.App.BodySm.Medium"
+                 />
+
+            <TextView
+                android:id="@+id/btn_tab_route"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:text="경로 일정"
+                android:textAppearance="@style/TextAppearance.App.BodySm.Medium"
+                android:textColor="@color/gray_600" />
+        </LinearLayout>
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/viewPager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="8dp" />
+
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_general_schedule.xml
+++ b/app/src/main/res/layout/fragment_general_schedule.xml
@@ -1,133 +1,93 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#F0F0F0"
-    android:fillViewport="true">
+    android:fitsSystemWindows="true"
+    android:background="#F5F5F5">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:animateLayoutChanges="true">
-
+        android:orientation="vertical" >
 
         <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@android:color/white"
-        android:orientation="vertical">
-
-        <RelativeLayout
-            android:id="@+id/layout_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_schedule"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:animateLayoutChanges="true">
 
-            <ImageView
-                android:id="@+id/btn_back"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_centerVertical="true"
-                android:src="@drawable/ic_arrow_opened"/>
-
-            <TextView
-                android:id="@+id/tv_toolbar_title"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:text="새로운 일정 추가"
-                android:textColor="@color/black"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:paddingVertical="15dp" />
-
-            <ImageView
-                android:id="@+id/btn_save"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_centerVertical="true"
-                android:layout_alignParentEnd="true"
-                android:src="@drawable/ic_check" />
-
-        </RelativeLayout>
-    </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/layout_tab_selector"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="12dp"
-
-            android:background="@color/gray_200"
-            android:orientation="horizontal"
-            android:padding="2dp">
-
-            <TextView
-                android:id="@+id/btn_tab_general"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:background="#E0E0E0"
-                android:fontFamily="@font/pretendard_medium"
-                android:gravity="center"
-                android:text="일반 일정"
-                android:textColor="@color/gray_500"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/btn_tab_route"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:background="@color/white"
-                android:elevation="1dp"
-                android:fontFamily="@font/pretendard_medium"
-                android:gravity="center"
-                android:paddingVertical="15dp"
-                android:text="경로 일정"
-                android:textColor="@color/black"
-                android:textSize="14sp"
-                android:textStyle="bold" />
-
-        </LinearLayout>
-
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="12dp"
-            android:background="@color/white"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:padding="16dp">
-
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
             <View
                 android:id="@+id/view_color_dot"
-                android:layout_marginHorizontal="8dp"
                 android:layout_width="12dp"
                 android:layout_height="12dp"
-                android:background="@color/schedule_5" />
+                android:padding="8dp"
+                android:background="@drawable/circle_schedulecolor"
+                android:backgroundTint="@color/schedule_5"
+                />
 
 
             <EditText
                 android:id="@+id/et_schedule_name"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="12dp"
+                android:layout_marginStart="4dp"
                 android:background="@null"
-                android:fontFamily="@font/pretendard_regular"
+                android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
                 android:hint="일정명"
                 android:importantForAutofill="no"
                 android:inputType="text"
-                android:textColor="@color/black"
-                android:textSize="14sp" />
+                android:textColor="@color/black" />
+
+        </LinearLayout>
+            <LinearLayout
+                android:id="@+id/layout_color_selector"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginTop="4dp"
+                android:background="@drawable/box_schedule"
+                android:orientation="horizontal"
+                android:padding="12dp"
+                android:gravity="center"
+                android:visibility="gone">
+
+                <View
+                android:id="@+id/color_red"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_marginHorizontal="8dp"
+                android:background="@drawable/circle_schedulecolor"
+                android:backgroundTint="#F44336" />
+
+                <View
+                    android:id="@+id/color_pink"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginHorizontal="8dp"
+                    android:background="@drawable/circle_schedulecolor"
+                    android:backgroundTint="#E91E63" />
+
+                <View
+                    android:id="@+id/color_green"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginHorizontal="8dp"
+                    android:background="@drawable/circle_schedulecolor"
+                    android:backgroundTint="#4CAF50" />
+
+            </LinearLayout>
 
         </LinearLayout>
 
@@ -136,9 +96,12 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="12dp"
-            android:background="@color/white"
+            android:background="@drawable/box_schedule"
+            android:padding="16dp"
             android:orientation="vertical"
-            android:padding="16dp">
+            android:gravity="center_vertical"
+            app:layout_constraintTop_toBottomOf="@id/addsche_toolbar"
+            app:layout_constraintStart_toStartOf="parent">
 
             <RelativeLayout
                 android:layout_width="match_parent"
@@ -153,28 +116,28 @@
 
                     <ImageView
                         android:id="@+id/btn_all_day"
-                        android:layout_width="20.5dp"
-                        android:layout_height="20.5dp"
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
                         android:src="@drawable/ic_time" />
 
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:paddingVertical="3.5dp"
+                        android:layout_marginStart="4dp"
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
                         android:text="하루 종일"
-                        android:textColor="@color/gray_500"
-                        android:textSize="14sp" />
+                        android:textColor="@color/black" />
                 </LinearLayout>
 
-                <androidx.appcompat.widget.SwitchCompat
-                    android:id="@+id/switch_all_day"
-                    android:layout_width="40dp"
-                    android:layout_height="20dp"
-                    android:layout_alignParentEnd="true"
-                    app:thumbTint="@android:color/white"
-                    app:trackTint="#A4C639" />
+                <ImageView
+                    android:id="@+id/addsche_my_phone_iv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:src="@drawable/ic_toggle_selected"
+                    android:layout_alignParentRight="true"
+                    android:layout_centerVertical="true" />
+
             </RelativeLayout>
 
             <View
@@ -200,19 +163,15 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:text="2월 20일 (금)"
-                        android:textColor="#212529"
-                        android:textSize="16sp" />
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="2월 20일 (금)" />
                     <TextView
                         android:id="@+id/tv_start_time"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="4dp"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:text="오전 10:00"
-                        android:textColor="#2196F3"
-                        android:textSize="14sp" />
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="오전 10:00" />
                 </LinearLayout>
 
                 <ImageView
@@ -230,19 +189,15 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:text="2월 20일 (금)"
-                        android:textColor="#212529"
-                        android:textSize="16sp" />
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="2월 20일 (금)" />
                     <TextView
                         android:id="@+id/tv_end_time"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="4dp"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:text="오전 11:00"
-                        android:textColor="#2196F3"
-                        android:textSize="14sp" />
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="오전 11:00" />
                 </LinearLayout>
             </LinearLayout>
 
@@ -255,21 +210,26 @@
             <LinearLayout
                 android:id="@+id/time_picker_container"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="200dp"
                 android:gravity="center"
+                android:orientation="horizontal"
                 android:visibility="gone">
-
-                <NumberPicker
-
-                    android:id="@+id/picker_ampm"
-                    android:layout_width="wrap_content"
-                    android:layout_height="120dp" />
 
                 <NumberPicker
 
                     android:id="@+id/picker_hour"
                     android:layout_width="wrap_content"
-                    android:layout_height="120dp" />
+                    android:layout_height="120dp"
+                    android:fadingEdgeLength="40dp"
+                    android:requiresFadingEdge="vertical" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text=":"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    android:layout_marginHorizontal="8dp"/>
 
                 <NumberPicker
 
@@ -299,12 +259,12 @@
                     android:src="@drawable/ic_arrow_change" />
 
                 <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:fontFamily="@font/pretendard_regular"
-                android:text="반복 안함" android:textColor="@color/gray_500"
-                android:textSize="14sp" />
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:text="반복 안함"
+                    android:textColor="@color/gray_500" />
             </LinearLayout>
 
         </LinearLayout>
@@ -314,7 +274,39 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="12dp"
-            android:background="@color/white"
+            android:background="@drawable/box_schedule"
+            android:orientation="horizontal"
+            android:padding="16dp">
+
+            <LinearLayout
+                android:id="@+id/btn_route"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_route_unselected" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:text="장소"
+                    android:textColor="@color/gray_500" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_schedule"
             android:orientation="horizontal"
             android:padding="16dp">
 
@@ -326,18 +318,17 @@
                 android:orientation="horizontal">
 
                 <ImageView
-                    android:layout_width="20.5dp"
-                    android:layout_height="20.5dp"
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
                     android:src="@drawable/ic_alarm_remind_unselected" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:fontFamily="@font/pretendard_regular"
-                    android:text="리마인드 알림 안함"
-                    android:textColor="@color/gray_500"
-                    android:textSize="14sp" />
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:text="일정 알림 안함"
+                    android:textColor="@color/gray_500" />
             </LinearLayout>
 
         </LinearLayout>
@@ -347,7 +338,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="12dp"
-            android:background="@color/white"
+            android:background="@drawable/box_schedule"
             android:orientation="horizontal"
             android:padding="16dp">
 
@@ -358,13 +349,23 @@
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_alarm_remind_unselected" />
+
                 <EditText
+                    android:id="@+id/et_memo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:fontFamily="@font/pretendard_regular"
-                    android:text="메모"
-                    android:textColor="@color/gray_500"
-                    android:textSize="14sp" />
+                    android:layout_marginStart="4dp"
+                    android:background="@null"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:hint="메모"
+                    android:importantForAutofill="no"
+                    android:inputType="text"
+                    android:textColor="@color/black" />
+
             </LinearLayout>
 
         </LinearLayout>
@@ -374,30 +375,29 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="12dp"
-            android:background="@color/white"
+            android:background="@drawable/box_schedule"
             android:orientation="horizontal"
             android:padding="16dp">
 
             <LinearLayout
                 android:id="@+id/btn_calendar"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
                 <ImageView
-                    android:layout_width="20.5dp"
-                    android:layout_height="20.5dp"
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
                     android:src="@drawable/ic_day_unselected" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:fontFamily="@font/pretendard_regular"
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
                     android:text="캘린더"
-                    android:textColor="@color/gray_500"
-                    android:textSize="14sp" />
+                    android:textColor="@color/gray_500" />
             </LinearLayout>
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_route_schedule.xml
+++ b/app/src/main/res/layout/fragment_route_schedule.xml
@@ -1,0 +1,383 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:background="#F5F5F5">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_schedule"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:padding="16dp">
+
+            <View
+                android:id="@+id/view_color_dot"
+                android:layout_width="12dp"
+                android:layout_height="12dp"
+                android:padding="8dp"
+                android:background="@drawable/circle_schedulecolor"
+                android:backgroundTint="@color/schedule_5"
+                />
+
+
+            <EditText
+                android:id="@+id/et_schedule_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:background="@null"
+                android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                android:hint="일정명"
+                android:importantForAutofill="no"
+                android:inputType="text"
+                android:textColor="@color/black" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_schedule"
+            android:padding="16dp"
+            android:orientation="vertical"
+            android:gravity="center_vertical"
+            app:layout_constraintTop_toBottomOf="@id/addsche_toolbar"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <ImageView
+                        android:id="@+id/btn_all_day"
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:src="@drawable/ic_time" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="4dp"
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="하루 종일"
+                        android:textColor="@color/black" />
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/addsche_my_phone_iv"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:src="@drawable/ic_toggle_selected"
+                    android:layout_alignParentRight="true"
+                    android:layout_centerVertical="true" />
+
+            </RelativeLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginVertical="16dp"
+                android:background="#F1F3F5" />
+
+            <LinearLayout
+                android:id="@+id/layout_date_display"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:id="@+id/btn_start_date"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:orientation="vertical">
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="2월 20일 (금)" />
+                    <TextView
+                        android:id="@+id/tv_start_time"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="오전 10:00" />
+                </LinearLayout>
+
+                <ImageView
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:src="@drawable/ic_arrow_indicate_selected" />
+
+                <LinearLayout
+                    android:id="@+id/btn_end_date"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:orientation="vertical">
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="2월 20일 (금)" />
+                    <TextView
+                        android:id="@+id/tv_end_time"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                        android:text="오전 11:00" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <CalendarView
+                android:id="@+id/calendar_picker"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
+
+            <LinearLayout
+                android:id="@+id/time_picker_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:visibility="gone">
+
+                <NumberPicker
+
+                    android:id="@+id/picker_ampm"
+                    android:layout_width="wrap_content"
+                    android:layout_height="120dp" />
+
+                <NumberPicker
+
+                    android:id="@+id/picker_hour"
+                    android:layout_width="wrap_content"
+                    android:layout_height="120dp" />
+
+                <NumberPicker
+
+                    android:id="@+id/picker_minute"
+                    android:layout_width="wrap_content"
+                    android:layout_height="120dp" />
+
+            </LinearLayout>
+
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="16dp"
+                android:background="#F1F3F5" />
+
+            <LinearLayout
+                android:id="@+id/btn_repeat"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:src="@drawable/ic_arrow_change" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:text="반복 안함"
+                    android:textColor="@color/gray_500" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_schedule"
+            android:orientation="horizontal"
+            android:padding="16dp">
+
+            <LinearLayout
+                android:id="@+id/btn_route"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_route_unselected" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:text="장소"
+                    android:textColor="@color/gray_500" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_schedule"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <LinearLayout
+                android:id="@+id/btn_remindalarm"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_alarm_remind_unselected" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:text="일정 알림 안함"
+                    android:textColor="@color/gray_500" />
+
+            </LinearLayout>
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginVertical="16dp"
+                android:background="#F1F3F5" />
+            <LinearLayout
+                android:id="@+id/btn_startalarm"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_alarm_remind_unselected" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:text="출발 알림 안함"
+                    android:textColor="@color/gray_500" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_schedule"
+            android:orientation="horizontal"
+            android:padding="16dp">
+
+            <LinearLayout
+                android:id="@+id/btn_memo"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_alarm_remind_unselected" />
+
+                <EditText
+                    android:id="@+id/et_memo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:background="@null"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:hint="메모"
+                    android:importantForAutofill="no"
+                    android:inputType="text"
+                    android:textColor="@color/black" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/box_schedule"
+            android:orientation="horizontal"
+            android:padding="16dp">
+
+            <LinearLayout
+                android:id="@+id/btn_calendar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:src="@drawable/ic_day_unselected" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+                    android:text="캘린더"
+                    android:textColor="@color/gray_500" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -22,4 +22,6 @@
 
 
     <style name="Theme.Pace" parent="Base.Theme.Pace" />
+
+
 </resources>


### PR DESCRIPTION
# PR템플릿 

## 변경 사항 요약
- 변경사항 요약본 작성
새로운일정추가에서 일반일정과 경로일정 대표화면구현. 타임피커와 일정명옆에있는아이콘을 누르면 색상이뜨게 만듬.
탭셀렉터에서 클릭하면 흰색배경도 같이 옯겨져야 하는데 그부분은 구현중에 있음
캘린더뷰는 반영안했고 manifast도 빌드되는지만 확인하고 안건들였습니다.
혹시나 시간되시면 fetch해보시고 안되는 부분이나 이상한부분 알려주세요!

## 체크리스트
- [x] 코드 빌드 성공
- [x] 에뮬레이터 실행 시 성공

## 사진올리는곳
<img width="1080" height="2408" alt="image" src="https://github.com/user-attachments/assets/6b2013fe-86ef-4e4e-a3db-87408159a2b6" />
<img width="1080" height="2408" alt="image" src="https://github.com/user-attachments/assets/ea69bc5c-0309-4254-902c-908d30ff8d9f" />
