### PR TITLE
[Feat] 캘린더 바텀시트 높이조절에 따른 애니매이션 효과 추가

### DIFF
--- a/.kotlin/errors/errors-1769061342480.log
+++ b/.kotlin/errors/errors-1769061342480.log
@@ -1,0 +1,110 @@
+kotlin version: 2.0.21
+error message: org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during IR lowering
+File being compiled: C:/Users/sshhs/AndroidStudioProjects/Pace/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
+The root cause java.lang.RuntimeException was thrown at: org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:47)
+	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException(CodegenUtil.kt:253)
+	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException$default(CodegenUtil.kt:236)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invokeSequential(performByIrFile.kt:65)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invoke(performByIrFile.kt:52)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invoke(performByIrFile.kt:38)
+	at org.jetbrains.kotlin.backend.common.phaser.NamedCompilerPhase.phaseBody(CompilerPhase.kt:166)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:27)
+	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:14)
+	at org.jetbrains.kotlin.backend.common.phaser.NamedCompilerPhase.phaseBody(CompilerPhase.kt:166)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:62)
+	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.invokeCodegen(JvmIrCodegenFactory.kt:371)
+	at org.jetbrains.kotlin.codegen.CodegenFactory.generateModule(CodegenFactory.kt:47)
+	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.generateModuleInFrontendIRMode(JvmIrCodegenFactory.kt:433)
+	at org.jetbrains.kotlin.cli.jvm.compiler.pipeline.JvmCompilerPipelineKt.generateCodeFromIr(jvmCompilerPipeline.kt:246)
+	at org.jetbrains.kotlin.cli.jvm.compiler.pipeline.JvmCompilerPipelineKt.compileModulesUsingFrontendIrAndLightTree(jvmCompilerPipeline.kt:142)
+	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:148)
+	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:43)
+	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:103)
+	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:49)
+	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
+	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:464)
+	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:73)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:506)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:423)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.tryCompileIncrementally$lambda$9$compile(IncrementalCompilerRunner.kt:249)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.tryCompileIncrementally(IncrementalCompilerRunner.kt:267)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:120)
+	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:675)
+	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:92)
+	at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1660)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
+	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
+	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
+	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport.serviceCall(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(Unknown Source)
+	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
+	at java.base/java.lang.Thread.run(Unknown Source)
+Caused by: java.lang.RuntimeException: Exception while generating code for:
+FUN LOCAL_FUNCTION_FOR_LAMBDA name:onViewCreated$lambda$1 visibility:private modality:FINAL <> (this$0:com.example.pace.ui.main.calendar.CalendarPageFragment) returnType:kotlin.Unit
+  VALUE_PARAMETER BOUND_VALUE_PARAMETER name:this$0 index:0 type:com.example.pace.ui.main.calendar.CalendarPageFragment
+  BLOCK_BODY
+    VAR name:screenHeight type:kotlin.Int [val]
+      GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:heightPixels type:kotlin.Int visibility:public declared in android.util.DisplayMetrics' type=kotlin.Int superQualifierSymbol=android.util.DisplayMetrics origin=null
+        receiver: CALL 'public open fun getDisplayMetrics (): @[FlexibleNullability] android.util.DisplayMetrics? declared in android.content.res.Resources' type=@[FlexibleNullability] android.util.DisplayMetrics? origin=GET_PROPERTY
+          $this: CALL 'public final fun getResources (): @[EnhancedNullability] android.content.res.Resources [fake_override] declared in com.example.pace.ui.main.calendar.CalendarPageFragment' type=@[EnhancedNullability] android.content.res.Resources origin=GET_PROPERTY
+            $this: GET_VAR 'this$0: com.example.pace.ui.main.calendar.CalendarPageFragment declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=com.example.pace.ui.main.calendar.CalendarPageFragment origin=null
+    SET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:maxHeight type:kotlin.Int visibility:public [final,static] declared in android.R.attr' type=kotlin.Unit superQualifierSymbol=android.R.attr origin=EQ
+      value: CALL 'public final fun div (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=DIV
+        $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=MUL
+          $this: GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+          other: CONST Int type=kotlin.Int value=8
+        other: CONST Int type=kotlin.Int value=10
+    COMPOSITE type=kotlin.Unit origin=null
+      CALL 'public open fun d (p0: @[EnhancedNullability] kotlin.String?, p1: @[EnhancedNullability] kotlin.String): kotlin.Int declared in android.util.Log' type=kotlin.Int origin=null
+        p0: CONST String type=kotlin.String value="BottomSheetMax"
+        p1: STRING_CONCATENATION type=kotlin.String
+          CONST String type=kotlin.String value="screenHeight="
+          GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+          CONST String type=kotlin.String value=", maxHeight=16843040"
+      COMPOSITE type=kotlin.Unit origin=null
+
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:47)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate$default(FunctionCodegen.kt:40)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generateMethodNode(ClassCodegen.kt:406)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generateMethod(ClassCodegen.kt:423)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generate(ClassCodegen.kt:168)
+	at org.jetbrains.kotlin.backend.jvm.FileCodegen.lower(JvmPhases.kt:39)
+	at org.jetbrains.kotlin.backend.common.phaser.PhaseFactoriesKt.createFilePhase$lambda$4(PhaseFactories.kt:71)
+	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$createSimpleNamedCompilerPhase$1.phaseBody(PhaseBuilders.kt:69)
+	at org.jetbrains.kotlin.backend.common.phaser.SimpleNamedCompilerPhase.phaseBody(CompilerPhase.kt:226)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invokeSequential(performByIrFile.kt:62)
+	... 44 more
+Caused by: java.lang.AssertionError: access of const val: SET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:maxHeight type:kotlin.Int visibility:public [final,static] declared in android.R.attr' type=kotlin.Unit superQualifierSymbol=android.R.attr origin=EQ
+  value: CALL 'public final fun div (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=DIV
+    $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=MUL
+      $this: GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+      other: CONST Int type=kotlin.Int value=8
+    other: CONST Int type=kotlin.Int value=10
+
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitFieldAccess(ExpressionCodegen.kt:861)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitFieldAccess(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.visitors.IrElementVisitor$DefaultImpls.visitSetField(IrElementVisitor.kt:206)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitSetField(ExpressionCodegen.kt:908)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitSetField(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.expressions.IrSetField.accept(IrSetField.kt:21)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitStatementContainer(ExpressionCodegen.kt:579)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitBlockBody(ExpressionCodegen.kt:584)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitBlockBody(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.expressions.IrBlockBody.accept(IrBlockBody.kt:20)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.generate(ExpressionCodegen.kt:240)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.doGenerate(FunctionCodegen.kt:123)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:44)
+	... 54 more
+
+

--- a/.kotlin/errors/errors-1769061351702.log
+++ b/.kotlin/errors/errors-1769061351702.log
@@ -1,0 +1,110 @@
+kotlin version: 2.0.21
+error message: org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during IR lowering
+File being compiled: C:/Users/sshhs/AndroidStudioProjects/Pace/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
+The root cause java.lang.RuntimeException was thrown at: org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:47)
+	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException(CodegenUtil.kt:253)
+	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException$default(CodegenUtil.kt:236)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invokeSequential(performByIrFile.kt:65)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invoke(performByIrFile.kt:52)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invoke(performByIrFile.kt:38)
+	at org.jetbrains.kotlin.backend.common.phaser.NamedCompilerPhase.phaseBody(CompilerPhase.kt:166)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:27)
+	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:14)
+	at org.jetbrains.kotlin.backend.common.phaser.NamedCompilerPhase.phaseBody(CompilerPhase.kt:166)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:62)
+	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.invokeCodegen(JvmIrCodegenFactory.kt:371)
+	at org.jetbrains.kotlin.codegen.CodegenFactory.generateModule(CodegenFactory.kt:47)
+	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.generateModuleInFrontendIRMode(JvmIrCodegenFactory.kt:433)
+	at org.jetbrains.kotlin.cli.jvm.compiler.pipeline.JvmCompilerPipelineKt.generateCodeFromIr(jvmCompilerPipeline.kt:246)
+	at org.jetbrains.kotlin.cli.jvm.compiler.pipeline.JvmCompilerPipelineKt.compileModulesUsingFrontendIrAndLightTree(jvmCompilerPipeline.kt:142)
+	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:148)
+	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:43)
+	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:103)
+	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:49)
+	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
+	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:464)
+	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:73)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:506)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:423)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.tryCompileIncrementally$lambda$9$compile(IncrementalCompilerRunner.kt:249)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.tryCompileIncrementally(IncrementalCompilerRunner.kt:267)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:120)
+	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:675)
+	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:92)
+	at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1660)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
+	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
+	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
+	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport.serviceCall(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(Unknown Source)
+	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
+	at java.base/java.lang.Thread.run(Unknown Source)
+Caused by: java.lang.RuntimeException: Exception while generating code for:
+FUN LOCAL_FUNCTION_FOR_LAMBDA name:onViewCreated$lambda$1 visibility:private modality:FINAL <> (this$0:com.example.pace.ui.main.calendar.CalendarPageFragment) returnType:kotlin.Unit
+  VALUE_PARAMETER BOUND_VALUE_PARAMETER name:this$0 index:0 type:com.example.pace.ui.main.calendar.CalendarPageFragment
+  BLOCK_BODY
+    VAR name:screenHeight type:kotlin.Int [val]
+      GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:heightPixels type:kotlin.Int visibility:public declared in android.util.DisplayMetrics' type=kotlin.Int superQualifierSymbol=android.util.DisplayMetrics origin=null
+        receiver: CALL 'public open fun getDisplayMetrics (): @[FlexibleNullability] android.util.DisplayMetrics? declared in android.content.res.Resources' type=@[FlexibleNullability] android.util.DisplayMetrics? origin=GET_PROPERTY
+          $this: CALL 'public final fun getResources (): @[EnhancedNullability] android.content.res.Resources [fake_override] declared in com.example.pace.ui.main.calendar.CalendarPageFragment' type=@[EnhancedNullability] android.content.res.Resources origin=GET_PROPERTY
+            $this: GET_VAR 'this$0: com.example.pace.ui.main.calendar.CalendarPageFragment declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=com.example.pace.ui.main.calendar.CalendarPageFragment origin=null
+    SET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:maxHeight type:kotlin.Int visibility:public [final,static] declared in android.R.attr' type=kotlin.Unit superQualifierSymbol=android.R.attr origin=EQ
+      value: CALL 'public final fun div (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=DIV
+        $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=MUL
+          $this: GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+          other: CONST Int type=kotlin.Int value=8
+        other: CONST Int type=kotlin.Int value=10
+    COMPOSITE type=kotlin.Unit origin=null
+      CALL 'public open fun d (p0: @[EnhancedNullability] kotlin.String?, p1: @[EnhancedNullability] kotlin.String): kotlin.Int declared in android.util.Log' type=kotlin.Int origin=null
+        p0: CONST String type=kotlin.String value="BottomSheetMax"
+        p1: STRING_CONCATENATION type=kotlin.String
+          CONST String type=kotlin.String value="screenHeight="
+          GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+          CONST String type=kotlin.String value=", maxHeight=16843040"
+      COMPOSITE type=kotlin.Unit origin=null
+
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:47)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate$default(FunctionCodegen.kt:40)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generateMethodNode(ClassCodegen.kt:406)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generateMethod(ClassCodegen.kt:423)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generate(ClassCodegen.kt:168)
+	at org.jetbrains.kotlin.backend.jvm.FileCodegen.lower(JvmPhases.kt:39)
+	at org.jetbrains.kotlin.backend.common.phaser.PhaseFactoriesKt.createFilePhase$lambda$4(PhaseFactories.kt:71)
+	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$createSimpleNamedCompilerPhase$1.phaseBody(PhaseBuilders.kt:69)
+	at org.jetbrains.kotlin.backend.common.phaser.SimpleNamedCompilerPhase.phaseBody(CompilerPhase.kt:226)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invokeSequential(performByIrFile.kt:62)
+	... 44 more
+Caused by: java.lang.AssertionError: access of const val: SET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:maxHeight type:kotlin.Int visibility:public [final,static] declared in android.R.attr' type=kotlin.Unit superQualifierSymbol=android.R.attr origin=EQ
+  value: CALL 'public final fun div (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=DIV
+    $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=MUL
+      $this: GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+      other: CONST Int type=kotlin.Int value=8
+    other: CONST Int type=kotlin.Int value=10
+
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitFieldAccess(ExpressionCodegen.kt:861)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitFieldAccess(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.visitors.IrElementVisitor$DefaultImpls.visitSetField(IrElementVisitor.kt:206)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitSetField(ExpressionCodegen.kt:908)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitSetField(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.expressions.IrSetField.accept(IrSetField.kt:21)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitStatementContainer(ExpressionCodegen.kt:579)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitBlockBody(ExpressionCodegen.kt:584)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitBlockBody(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.expressions.IrBlockBody.accept(IrBlockBody.kt:20)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.generate(ExpressionCodegen.kt:240)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.doGenerate(FunctionCodegen.kt:123)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:44)
+	... 54 more
+
+

--- a/.kotlin/errors/errors-1769061405979.log
+++ b/.kotlin/errors/errors-1769061405979.log
@@ -1,0 +1,110 @@
+kotlin version: 2.0.21
+error message: org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during IR lowering
+File being compiled: C:/Users/sshhs/AndroidStudioProjects/Pace/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
+The root cause java.lang.RuntimeException was thrown at: org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:47)
+	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException(CodegenUtil.kt:253)
+	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException$default(CodegenUtil.kt:236)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invokeSequential(performByIrFile.kt:65)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invoke(performByIrFile.kt:52)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invoke(performByIrFile.kt:38)
+	at org.jetbrains.kotlin.backend.common.phaser.NamedCompilerPhase.phaseBody(CompilerPhase.kt:166)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:27)
+	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:14)
+	at org.jetbrains.kotlin.backend.common.phaser.NamedCompilerPhase.phaseBody(CompilerPhase.kt:166)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:62)
+	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.invokeCodegen(JvmIrCodegenFactory.kt:371)
+	at org.jetbrains.kotlin.codegen.CodegenFactory.generateModule(CodegenFactory.kt:47)
+	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.generateModuleInFrontendIRMode(JvmIrCodegenFactory.kt:433)
+	at org.jetbrains.kotlin.cli.jvm.compiler.pipeline.JvmCompilerPipelineKt.generateCodeFromIr(jvmCompilerPipeline.kt:246)
+	at org.jetbrains.kotlin.cli.jvm.compiler.pipeline.JvmCompilerPipelineKt.compileModulesUsingFrontendIrAndLightTree(jvmCompilerPipeline.kt:142)
+	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:148)
+	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:43)
+	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:103)
+	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:49)
+	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
+	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:464)
+	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:73)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:506)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:423)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.tryCompileIncrementally$lambda$9$compile(IncrementalCompilerRunner.kt:249)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.tryCompileIncrementally(IncrementalCompilerRunner.kt:267)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:120)
+	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:675)
+	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:92)
+	at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1660)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
+	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
+	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
+	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport.serviceCall(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(Unknown Source)
+	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
+	at java.base/java.lang.Thread.run(Unknown Source)
+Caused by: java.lang.RuntimeException: Exception while generating code for:
+FUN LOCAL_FUNCTION_FOR_LAMBDA name:onViewCreated$lambda$1 visibility:private modality:FINAL <> (this$0:com.example.pace.ui.main.calendar.CalendarPageFragment) returnType:kotlin.Unit
+  VALUE_PARAMETER BOUND_VALUE_PARAMETER name:this$0 index:0 type:com.example.pace.ui.main.calendar.CalendarPageFragment
+  BLOCK_BODY
+    VAR name:screenHeight type:kotlin.Int [val]
+      GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:heightPixels type:kotlin.Int visibility:public declared in android.util.DisplayMetrics' type=kotlin.Int superQualifierSymbol=android.util.DisplayMetrics origin=null
+        receiver: CALL 'public open fun getDisplayMetrics (): @[FlexibleNullability] android.util.DisplayMetrics? declared in android.content.res.Resources' type=@[FlexibleNullability] android.util.DisplayMetrics? origin=GET_PROPERTY
+          $this: CALL 'public final fun getResources (): @[EnhancedNullability] android.content.res.Resources [fake_override] declared in com.example.pace.ui.main.calendar.CalendarPageFragment' type=@[EnhancedNullability] android.content.res.Resources origin=GET_PROPERTY
+            $this: GET_VAR 'this$0: com.example.pace.ui.main.calendar.CalendarPageFragment declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=com.example.pace.ui.main.calendar.CalendarPageFragment origin=null
+    SET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:maxHeight type:kotlin.Int visibility:public [final,static] declared in android.R.attr' type=kotlin.Unit superQualifierSymbol=android.R.attr origin=EQ
+      value: CALL 'public final fun div (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=DIV
+        $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=MUL
+          $this: GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+          other: CONST Int type=kotlin.Int value=8
+        other: CONST Int type=kotlin.Int value=10
+    COMPOSITE type=kotlin.Unit origin=null
+      CALL 'public open fun d (p0: @[EnhancedNullability] kotlin.String?, p1: @[EnhancedNullability] kotlin.String): kotlin.Int declared in android.util.Log' type=kotlin.Int origin=null
+        p0: CONST String type=kotlin.String value="BottomSheetMax"
+        p1: STRING_CONCATENATION type=kotlin.String
+          CONST String type=kotlin.String value="screenHeight="
+          GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+          CONST String type=kotlin.String value=", maxHeight=16843040"
+      COMPOSITE type=kotlin.Unit origin=null
+
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:47)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate$default(FunctionCodegen.kt:40)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generateMethodNode(ClassCodegen.kt:406)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generateMethod(ClassCodegen.kt:423)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generate(ClassCodegen.kt:168)
+	at org.jetbrains.kotlin.backend.jvm.FileCodegen.lower(JvmPhases.kt:39)
+	at org.jetbrains.kotlin.backend.common.phaser.PhaseFactoriesKt.createFilePhase$lambda$4(PhaseFactories.kt:71)
+	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$createSimpleNamedCompilerPhase$1.phaseBody(PhaseBuilders.kt:69)
+	at org.jetbrains.kotlin.backend.common.phaser.SimpleNamedCompilerPhase.phaseBody(CompilerPhase.kt:226)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invokeSequential(performByIrFile.kt:62)
+	... 44 more
+Caused by: java.lang.AssertionError: access of const val: SET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:maxHeight type:kotlin.Int visibility:public [final,static] declared in android.R.attr' type=kotlin.Unit superQualifierSymbol=android.R.attr origin=EQ
+  value: CALL 'public final fun div (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=DIV
+    $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=MUL
+      $this: GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+      other: CONST Int type=kotlin.Int value=8
+    other: CONST Int type=kotlin.Int value=10
+
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitFieldAccess(ExpressionCodegen.kt:861)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitFieldAccess(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.visitors.IrElementVisitor$DefaultImpls.visitSetField(IrElementVisitor.kt:206)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitSetField(ExpressionCodegen.kt:908)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitSetField(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.expressions.IrSetField.accept(IrSetField.kt:21)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitStatementContainer(ExpressionCodegen.kt:579)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitBlockBody(ExpressionCodegen.kt:584)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitBlockBody(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.expressions.IrBlockBody.accept(IrBlockBody.kt:20)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.generate(ExpressionCodegen.kt:240)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.doGenerate(FunctionCodegen.kt:123)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:44)
+	... 54 more
+
+

--- a/.kotlin/errors/errors-1769062352203.log
+++ b/.kotlin/errors/errors-1769062352203.log
@@ -1,0 +1,110 @@
+kotlin version: 2.0.21
+error message: org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during IR lowering
+File being compiled: C:/Users/sshhs/AndroidStudioProjects/Pace/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
+The root cause java.lang.RuntimeException was thrown at: org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:47)
+	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException(CodegenUtil.kt:253)
+	at org.jetbrains.kotlin.backend.common.CodegenUtil.reportBackendException$default(CodegenUtil.kt:236)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invokeSequential(performByIrFile.kt:65)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invoke(performByIrFile.kt:52)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invoke(performByIrFile.kt:38)
+	at org.jetbrains.kotlin.backend.common.phaser.NamedCompilerPhase.phaseBody(CompilerPhase.kt:166)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:27)
+	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:14)
+	at org.jetbrains.kotlin.backend.common.phaser.NamedCompilerPhase.phaseBody(CompilerPhase.kt:166)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:62)
+	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.invokeCodegen(JvmIrCodegenFactory.kt:371)
+	at org.jetbrains.kotlin.codegen.CodegenFactory.generateModule(CodegenFactory.kt:47)
+	at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.generateModuleInFrontendIRMode(JvmIrCodegenFactory.kt:433)
+	at org.jetbrains.kotlin.cli.jvm.compiler.pipeline.JvmCompilerPipelineKt.generateCodeFromIr(jvmCompilerPipeline.kt:246)
+	at org.jetbrains.kotlin.cli.jvm.compiler.pipeline.JvmCompilerPipelineKt.compileModulesUsingFrontendIrAndLightTree(jvmCompilerPipeline.kt:142)
+	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:148)
+	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:43)
+	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:103)
+	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:49)
+	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
+	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:464)
+	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:73)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:506)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:423)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.tryCompileIncrementally$lambda$9$compile(IncrementalCompilerRunner.kt:249)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.tryCompileIncrementally(IncrementalCompilerRunner.kt:267)
+	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:120)
+	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:675)
+	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:92)
+	at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1660)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
+	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
+	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport$1.run(Unknown Source)
+	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
+	at java.rmi/sun.rmi.transport.Transport.serviceCall(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(Unknown Source)
+	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
+	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
+	at java.base/java.lang.Thread.run(Unknown Source)
+Caused by: java.lang.RuntimeException: Exception while generating code for:
+FUN LOCAL_FUNCTION_FOR_LAMBDA name:onViewCreated$lambda$1 visibility:private modality:FINAL <> (this$0:com.example.pace.ui.main.calendar.CalendarPageFragment) returnType:kotlin.Unit
+  VALUE_PARAMETER BOUND_VALUE_PARAMETER name:this$0 index:0 type:com.example.pace.ui.main.calendar.CalendarPageFragment
+  BLOCK_BODY
+    VAR name:screenHeight type:kotlin.Int [val]
+      GET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:heightPixels type:kotlin.Int visibility:public declared in android.util.DisplayMetrics' type=kotlin.Int superQualifierSymbol=android.util.DisplayMetrics origin=null
+        receiver: CALL 'public open fun getDisplayMetrics (): @[FlexibleNullability] android.util.DisplayMetrics? declared in android.content.res.Resources' type=@[FlexibleNullability] android.util.DisplayMetrics? origin=GET_PROPERTY
+          $this: CALL 'public final fun getResources (): @[EnhancedNullability] android.content.res.Resources [fake_override] declared in com.example.pace.ui.main.calendar.CalendarPageFragment' type=@[EnhancedNullability] android.content.res.Resources origin=GET_PROPERTY
+            $this: GET_VAR 'this$0: com.example.pace.ui.main.calendar.CalendarPageFragment declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=com.example.pace.ui.main.calendar.CalendarPageFragment origin=null
+    SET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:maxHeight type:kotlin.Int visibility:public [final,static] declared in android.R.attr' type=kotlin.Unit superQualifierSymbol=android.R.attr origin=EQ
+      value: CALL 'public final fun div (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=DIV
+        $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=MUL
+          $this: GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+          other: CONST Int type=kotlin.Int value=8
+        other: CONST Int type=kotlin.Int value=10
+    COMPOSITE type=kotlin.Unit origin=null
+      CALL 'public open fun d (p0: @[EnhancedNullability] kotlin.String?, p1: @[EnhancedNullability] kotlin.String): kotlin.Int declared in android.util.Log' type=kotlin.Int origin=null
+        p0: CONST String type=kotlin.String value="BottomSheetMax"
+        p1: STRING_CONCATENATION type=kotlin.String
+          CONST String type=kotlin.String value="screenHeight="
+          GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+          CONST String type=kotlin.String value=", maxHeight=16843040"
+      COMPOSITE type=kotlin.Unit origin=null
+
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:47)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate$default(FunctionCodegen.kt:40)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generateMethodNode(ClassCodegen.kt:406)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generateMethod(ClassCodegen.kt:423)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ClassCodegen.generate(ClassCodegen.kt:168)
+	at org.jetbrains.kotlin.backend.jvm.FileCodegen.lower(JvmPhases.kt:39)
+	at org.jetbrains.kotlin.backend.common.phaser.PhaseFactoriesKt.createFilePhase$lambda$4(PhaseFactories.kt:71)
+	at org.jetbrains.kotlin.backend.common.phaser.PhaseBuildersKt$createSimpleNamedCompilerPhase$1.phaseBody(PhaseBuilders.kt:69)
+	at org.jetbrains.kotlin.backend.common.phaser.SimpleNamedCompilerPhase.phaseBody(CompilerPhase.kt:226)
+	at org.jetbrains.kotlin.backend.common.phaser.AbstractNamedCompilerPhase.invoke(CompilerPhase.kt:113)
+	at org.jetbrains.kotlin.backend.common.phaser.PerformByIrFilePhase.invokeSequential(performByIrFile.kt:62)
+	... 44 more
+Caused by: java.lang.AssertionError: access of const val: SET_FIELD 'FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:maxHeight type:kotlin.Int visibility:public [final,static] declared in android.R.attr' type=kotlin.Unit superQualifierSymbol=android.R.attr origin=EQ
+  value: CALL 'public final fun div (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=DIV
+    $this: CALL 'public final fun times (other: kotlin.Int): kotlin.Int [operator] declared in kotlin.Int' type=kotlin.Int origin=MUL
+      $this: GET_VAR 'val screenHeight: kotlin.Int [val] declared in com.example.pace.ui.main.calendar.CalendarPageFragment.onViewCreated$lambda$1' type=kotlin.Int origin=null
+      other: CONST Int type=kotlin.Int value=8
+    other: CONST Int type=kotlin.Int value=10
+
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitFieldAccess(ExpressionCodegen.kt:861)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitFieldAccess(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.visitors.IrElementVisitor$DefaultImpls.visitSetField(IrElementVisitor.kt:206)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitSetField(ExpressionCodegen.kt:908)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitSetField(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.expressions.IrSetField.accept(IrSetField.kt:21)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitStatementContainer(ExpressionCodegen.kt:579)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitBlockBody(ExpressionCodegen.kt:584)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.visitBlockBody(ExpressionCodegen.kt:138)
+	at org.jetbrains.kotlin.ir.expressions.IrBlockBody.accept(IrBlockBody.kt:20)
+	at org.jetbrains.kotlin.backend.jvm.codegen.ExpressionCodegen.generate(ExpressionCodegen.kt:240)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.doGenerate(FunctionCodegen.kt:123)
+	at org.jetbrains.kotlin.backend.jvm.codegen.FunctionCodegen.generate(FunctionCodegen.kt:44)
+	... 54 more
+
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,4 +55,8 @@ dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
     implementation("com.kizitonwose.calendar:view:2.5.1")
     implementation("com.kizitonwose.calendar:core:2.5.1")
+
+    //썽아 라이브러리
+    implementation("com.afollestad.material-dialogs:core:3.3.0")
+    implementation("com.afollestad.material-dialogs:color:3.3.0")
 }

--- a/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
@@ -1,8 +1,10 @@
 package com.example.pace.ui.main.calendar
 
+import androidx.transition.TransitionManager
 import android.app.AlertDialog
 import android.graphics.Color
 import android.os.Bundle
+import android.os.StrictMode
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,10 +14,8 @@ import android.widget.FrameLayout
 import android.widget.NumberPicker
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.content.ContextCompat
 import androidx.core.view.children
-import androidx.core.view.postDelayed
 import androidx.fragment.app.Fragment
 import com.example.pace.R
 import com.example.pace.databinding.FragmentCalendarPageBinding
@@ -29,6 +29,7 @@ import java.time.format.TextStyle
 import java.time.temporal.WeekFields
 import java.util.Locale
 
+
 class CalendarPageFragment: Fragment() {
     private var _binding: FragmentCalendarPageBinding? = null
     private val binding get() = _binding!!
@@ -39,7 +40,6 @@ class CalendarPageFragment: Fragment() {
     private val today = LocalDate.now()
 
     private var headerHeight = 0
-
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -53,35 +53,60 @@ class CalendarPageFragment: Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectAll()
+                .penaltyLog()
+                .penaltyFlashScreen()  // 디버그 시 화면 깜빡임으로 확인
+                .build()
+        )
+
+        bottomSheetBehavior = BottomSheetBehavior.from(binding.bottomSheet)
+
         //월간 캘린더뷰가 담기는 컨테이너가 변화하는 바텀시트 높이에 대응하여 동적으로 변하게 하기
         binding.calendarContainer.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
             override fun onGlobalLayout() {
                 binding.calendarContainer.viewTreeObserver.removeOnGlobalLayoutListener(this)
                 headerHeight = binding.headerContainer.height
+
+                // Temporarily make it invisible to get the height
+                binding.weekCalendarView.visibility = View.INVISIBLE
+                val weekViewHeight = binding.weekCalendarView.height
+                // Set it back to gone
+                binding.weekCalendarView.visibility = View.GONE
+
+                val screenHeight = binding.root.height
+                val desiredHeight = screenHeight - headerHeight - weekViewHeight
+                
+                val layoutParams = binding.bottomSheet.layoutParams
+                layoutParams.height = desiredHeight
+                binding.bottomSheet.layoutParams = layoutParams
+
                 adjustCalendarHeight()
             }
         })
 
-        bottomSheetBehavior = BottomSheetBehavior.from(binding.bottomSheet)
-        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
-        bottomSheetBehavior.peekHeight = 0
+        bottomSheetBehavior.apply {
+            state = BottomSheetBehavior.STATE_HIDDEN
+            peekHeight = 300
+            isFitToContents = true // We will control height by setting the container's height
+            isHideable = true
+            skipCollapsed = true // We want to skip collapsed on drag, but not on programmatic set
+        }
 
         binding.calendarNumberPickerBtnIv.setOnClickListener {
             showMonthYearPicker()
         }
 
         class DayViewContainer(view: View) : ViewContainer(view) {
-            //binding을 밑에서도 써야해서 findViewById를 사용했어야 했음
             val rootLayout: ConstraintLayout = view.findViewById(R.id.root_layout)
             val textView: TextView = view.findViewById(R.id.calendarDayText)
 
             lateinit var day: CalendarDay   // Month용
             lateinit var weekDay: WeekDay   // Week용
 
-            // 이거를 init에서 실행함으로써 다음달 캘린더로 넘어가도 클릭리스너를 계속해서 다시 안달아도됨
             init {
                 rootLayout.setOnClickListener {
-                    // 월간인지 주차별인지 나누어서 클릭리스너 작성
                     val date: LocalDate
                     val isThisMonth: Boolean
 
@@ -94,37 +119,34 @@ class CalendarPageFragment: Fragment() {
                             date = weekDay.date
                             isThisMonth = YearMonth.from(weekDay.date) == selectedMonth
                         }
-                        // 이거는 클릭무시하라는건데, setOnClickListener는 void형 함수라서 이런형태로 사용해서 람다조기종료를 한다고함
                         else -> return@setOnClickListener
                     }
 
-                    android.util.Log.d("CalendarClick", "clicked=$date, selected=$selectedDate, isThisMonth=$isThisMonth")
-
                     if (!isThisMonth) return@setOnClickListener
 
-
-                    // 공통 클릭 로직
-                    if (selectedDate == date) {
-                        // 같은 날짜를 다시 누르면 bottomSheet 토글
-                        if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {
-                            bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
-                            bottomSheetBehavior.peekHeight = 300
-                        } else {
-                            bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
-                        }
-                    } else {
-                        // 다른 날짜 선택
-                        if (bottomSheetBehavior.state != BottomSheetBehavior.STATE_HIDDEN) {
-                            bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
-                        }
+                    if (selectedDate != date) {
+                        // Different date clicked
                         val oldDate = selectedDate
                         selectedDate = date
-
                         binding.calendarView.notifyDateChanged(date)
                         oldDate?.let { binding.calendarView.notifyDateChanged(it) }
-
                         binding.weekCalendarView.notifyDateChanged(date)
                         oldDate?.let { binding.weekCalendarView.notifyDateChanged(it) }
+                        // If sheet was hidden, show it collapsed
+                        if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {
+                            bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+                        }
+                    } else {
+                        // Same date clicked, toggle
+                        when (bottomSheetBehavior.state) {
+                            BottomSheetBehavior.STATE_HIDDEN -> {
+                                bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+                            }
+                            // If collapsed or expanded, hide it
+                            else -> {
+                                bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+                            }
+                        }
                     }
                 }
             }
@@ -281,39 +303,54 @@ class CalendarPageFragment: Fragment() {
         // 바텀시트 움직임을 등록
         bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onStateChanged(bottomSheet: View, newState: Int) {
+                android.util.Log.d("BottomSheetState", "newState=$newState (${stateName(newState)})")
+                
+                TransitionManager.beginDelayedTransition(binding.root as ViewGroup)
+
                 when (newState) {
-                    BottomSheetBehavior.STATE_EXPANDED -> {
-                        binding.calendarView.visibility = View.GONE
-                        binding.weekCalendarView.visibility = View.VISIBLE
-                        binding.weekCalendarView.scrollToWeek(selectedDate ?: today)
-                    }
-                    BottomSheetBehavior.STATE_COLLAPSED -> {
-                        binding.calendarView.visibility = View.VISIBLE
-                        binding.weekCalendarView.visibility = View.GONE
-                        selectedDate?.let { binding.calendarView.scrollToMonth(YearMonth.from(it)) }
-
-
-                        bottomSheet.post {
-                            val containerHeight = binding.calendarContainer.height
-                            val bottomSheetHeight = bottomSheet.height.takeIf { it > 0 } ?: 300
-                            val calendarHeight = containerHeight - headerHeight - bottomSheetHeight
-                            if (calendarHeight > 0) {
-                                binding.calendarView.layoutParams.height = calendarHeight
-                                binding.calendarView.requestLayout()
-                            }
-                        }
-                    }
                     BottomSheetBehavior.STATE_HIDDEN -> {
                         binding.calendarView.visibility = View.VISIBLE
                         binding.weekCalendarView.visibility = View.GONE
                         selectedDate?.let { binding.calendarView.scrollToMonth(YearMonth.from(it)) }
                         adjustCalendarHeight()
                     }
+
+                    BottomSheetBehavior.STATE_COLLAPSED -> {
+                        binding.calendarView.visibility = View.VISIBLE
+                        binding.weekCalendarView.visibility = View.GONE
+                        selectedDate?.let { binding.calendarView.scrollToMonth(YearMonth.from(it)) }
+
+                        // 높이 재계산
+                        val containerHeight = binding.calendarContainer.height
+                        val bottomSheetHeight = bottomSheetBehavior.peekHeight
+                        val calendarHeight = containerHeight - headerHeight - bottomSheetHeight
+                        if (calendarHeight > 0) {
+                            binding.calendarView.layoutParams.height = calendarHeight
+                            binding.calendarView.requestLayout()
+                        }
+                    }
+
+                    BottomSheetBehavior.STATE_EXPANDED -> {
+                        binding.calendarView.visibility = View.GONE
+                        binding.weekCalendarView.visibility = View.VISIBLE
+                        binding.weekCalendarView.scrollToWeek(selectedDate ?: today)
+                    }
                 }
             }
+            override fun onSlide(bottomSheet: View, slideOffset: Float) {
 
-            override fun onSlide(bottomSheet: View, slideOffset: Float) {}
+            }
         })
+
+    }
+    private fun stateName(state: Int): String = when (state) {
+        BottomSheetBehavior.STATE_HIDDEN -> "HIDDEN"
+        BottomSheetBehavior.STATE_COLLAPSED -> "COLLAPSED"
+        BottomSheetBehavior.STATE_EXPANDED -> "EXPANDED"
+        BottomSheetBehavior.STATE_DRAGGING -> "DRAGGING"
+        BottomSheetBehavior.STATE_SETTLING -> "SETTLING"
+        BottomSheetBehavior.STATE_HALF_EXPANDED -> "HALF_EXPANDED"
+        else -> "UNKNOWN($state)"
     }
 
 

--- a/app/src/main/res/layout/bottom_sheet_schedule.xml
+++ b/app/src/main/res/layout/bottom_sheet_schedule.xml
@@ -15,6 +15,7 @@
         android:textSize="18sp" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/bottom_sheet_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/fragment_calendar_page.xml
+++ b/app/src/main/res/layout/fragment_calendar_page.xml
@@ -81,16 +81,17 @@
         android:layout_marginEnd="20dp"
         app:cv_dayViewResource="@layout/item_calendar_day"
         app:layout_constraintTop_toBottomOf="@id/header_container"
-        android:visibility="gone"/>
+        android:visibility="invisible"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <FrameLayout
         android:id="@+id/bottom_sheet"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:behavior_hideable="true">
+        app:behavior_hideable="true"
+        app:behavior_peekHeight="0dp">
 
         <include layout="@layout/bottom_sheet_schedule" />
 


### PR DESCRIPTION
# PR템플릿 

## 변경 사항 요약
- 바텀시트 드래그 가능하게 하였고, 그에 따른 높이조절과 캘린더뷰 크기 조절, 높이 조절되면서 끊기지 않는 자연스럽게 늘어나고 줄어드는 애니매이션 효과 추가

## 체크리스트
- [v] 코드 빌드 성공
- [v] 에뮬레이터 실행 시 성공

## 사진올리는곳
애니매이션 효과라 사진으로 확인이 어려워 사진은 따로 추가 안했습니다.