### PR TITLE
Refactor/homefragment enhancement

### DIFF
--- a/app/src/main/java/com/example/pace/ui/main/home/DeleteScheduleDialog.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/DeleteScheduleDialog.kt
@@ -2,6 +2,8 @@ package com.example.pace.ui.main.home
 
 import android.app.Dialog
 import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import com.example.pace.databinding.DialogDeleteScheduleBinding
 import com.example.pace.databinding.DialogModalCaseBinding
@@ -12,5 +14,16 @@ class DeleteScheduleDialog(context: Context): Dialog(context) {
         super.onCreate(savedInstanceState)
         binding = DialogDeleteScheduleBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        binding.deleteScheduleCancelBtn.setOnClickListener {
+            dismiss()
+        }
+        binding.deleteScheduleCancelBtn2.setOnClickListener {
+            dismiss()
+        }
+    }
+    override fun onStart() {
+        super.onStart()
+        window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
     }
 }

--- a/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
@@ -12,12 +12,10 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.LinearSnapHelper
-import androidx.recyclerview.widget.PagerSnapHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.example.pace.databinding.FragmentHomeBinding
 import com.example.pace.ui.add_schedule.AddScheduleActivity
 import java.time.LocalDate
-import java.util.Locale
 
 class HomeFragment: Fragment() {
     lateinit var binding: FragmentHomeBinding
@@ -35,16 +33,28 @@ class HomeFragment: Fragment() {
         }
 
         // 일정뷰
-        val exampleList = listOf("Example1", "Example2", "Example3")
+        val exampleList = listOf<String>("Example 1", "Example 2", "Example 3")
+        // 일정 개수에 따라 뷰 변환하기
+        if(exampleList.size == 0){
+            binding.homeNoSchedule.visibility = View.VISIBLE
+            binding.homeScheduleRv.visibility = View.GONE
+        }else{
+            binding.homeNoSchedule.visibility = View.GONE
+            binding.homeScheduleRv.visibility = View.VISIBLE
+        }
+
         val scheduleAdapter = ScheduleRVAdapter(exampleList, requireContext())
+        val scheduleTouchHelper = ScheduleTouchHelper(scheduleAdapter)
+        val itemTouchHelper = ItemTouchHelper(scheduleTouchHelper)
+
         binding.homeScheduleRv.adapter = scheduleAdapter
         scheduleAdapter.setMyOnClickListener(object: ScheduleRVAdapter.MyOnClickListener{
             override fun showModalCase(position: Int) {
                 scheduleAdapter.showModalCase(position)
             }
         })
-        val scheduleTouchHelper = ItemTouchHelper(ScheduleTouchHelper())
-        scheduleTouchHelper.attachToRecyclerView(binding.homeScheduleRv)
+        scheduleAdapter.scheduleTouchHelper = scheduleTouchHelper
+        itemTouchHelper.attachToRecyclerView(binding.homeScheduleRv)
 
         // 하단 캘린더
         val calendarSize = 1000000

--- a/app/src/main/java/com/example/pace/ui/main/home/ScheduleRVAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/ScheduleRVAdapter.kt
@@ -1,7 +1,13 @@
 package com.example.pace.ui.main.home
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.DragEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
@@ -13,6 +19,13 @@ class ScheduleRVAdapter(
     private val context: Context
 ): RecyclerView.Adapter<ScheduleRVAdapter.ViewHolder>() {
     lateinit var mOnClickListener: MyOnClickListener
+    lateinit var scheduleTouchHelper: ScheduleTouchHelper
+
+    // 임시 리스트 추후 상태 프로퍼티로 수정
+    var swipedList = arrayListOf(false, false, false)
+
+    var isJustClosed = false
+    var closedPos = -1
 
     interface MyOnClickListener{
         fun showModalCase(position: Int)
@@ -30,15 +43,38 @@ class ScheduleRVAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.bind(scheduleList[position])
-        holder.binding.root.setOnClickListener {
-            showModalCase(position)
-        }
         holder.binding.schedulePinIv.setOnClickListener {
             holder.binding.schedulePinnedIv.visibility = View.VISIBLE
         }
         holder.binding.scheduleDeleteIv.setOnClickListener {
             val deleteScheduleDialog = DeleteScheduleDialog(context)
             deleteScheduleDialog.show()
+        }
+
+        @SuppressLint("ClickableViewAccessibility")
+        holder.binding.scheduleViewTop.setOnTouchListener { v, event ->
+            when(event.action){
+                MotionEvent.ACTION_DOWN -> {
+                    isJustClosed = false
+                }
+            }
+            false
+        }
+        holder.binding.scheduleViewTop.setOnClickListener {
+
+            if (swipedList[position]) {
+                scheduleTouchHelper.closeSwipedMenu()
+                swipedList[position] = false
+                isJustClosed = true
+                closedPos = position
+            } else {
+                if(closedPos != position){
+                    closedPos = -1
+                }else{
+                    showModalCase(position)
+                    closedPos = -1
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/pace/ui/main/home/ScheduleTouchHelper.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/ScheduleTouchHelper.kt
@@ -9,13 +9,15 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.example.pace.R
 
-class ScheduleTouchHelper(): ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
+class ScheduleTouchHelper(
+    private val adapter: ScheduleRVAdapter
+): ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT) {
     // 스와이프 범위
     private val leftWidth = dpToPx(70)
     private val rightWidth = dpToPx(120)
     // 스와이프된 상태 저장 변수
     private var currentScrollX = 0f
-    private var isMenuOpened = false
+    var isSwiping = false
     private var swipedViewHolder: RecyclerView.ViewHolder? = null
 
     override fun onMove(
@@ -47,6 +49,7 @@ class ScheduleTouchHelper(): ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.L
         actionState: Int,
         isCurrentlyActive: Boolean
     ) {
+        isSwiping = isCurrentlyActive
         if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE) {
             // 상단 뷰 찾기
             val viewTop = viewHolder.itemView.findViewById<ConstraintLayout>(R.id.schedule_view_top)
@@ -81,18 +84,18 @@ class ScheduleTouchHelper(): ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.L
                         else -> {
                             // 왼쪽 스크롤 및 임계점 도달
                             if(dX < 0 && currentScrollX == -rightWidth){
-                                isMenuOpened = true
+                                adapter.swipedList[viewHolder.bindingAdapterPosition] = true
                                 swipedViewHolder = viewHolder
                                 translationX = -rightWidth
                             }
                             // 우측 스크롤 및 임계점 도달
                             else if(dX > 0 && currentScrollX == leftWidth){
-                                isMenuOpened = true
+                                adapter.swipedList[viewHolder.bindingAdapterPosition] = true
                                 swipedViewHolder = viewHolder
                                 translationX = leftWidth
                             }
                             else{
-                                isMenuOpened = false
+                                adapter.swipedList[viewHolder.bindingAdapterPosition] = false
                                 translationX = 0f
                             }
                             // 상단 뷰 가로 위치 고정
@@ -105,6 +108,15 @@ class ScheduleTouchHelper(): ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.L
     }
 
     override fun getSwipeThreshold(viewHolder: RecyclerView.ViewHolder): Float = 2f
+
+    // 스와이프 메뉴 닫는 함수
+    fun closeSwipedMenu(){
+        val viewTop = swipedViewHolder?.itemView?.findViewById<ConstraintLayout>(R.id.schedule_view_top)
+        viewTop?.translationX = 0f
+        currentScrollX = 0f
+        swipedViewHolder = null
+    }
+
     private fun dpToPx(int: Int): Float {
         return int * Resources.getSystem().displayMetrics.densityDpi.toFloat() / DisplayMetrics.DENSITY_DEFAULT
     }

--- a/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
@@ -232,26 +232,6 @@ class RouteFragment : Fragment() {
         mainBinding?.mainToolbar?.visibility = View.VISIBLE
         mainBinding?.mainBackIv?.visibility = View.VISIBLE
 
-        binding.layoutMapSelectOverlay.visibility = View.VISIBLE
-        binding.layoutMapSelectOverlay.bringToFront()
-
-        val mapFrag = childFragmentManager.findFragmentById(R.id.route_map_fcv) as? MapFragment
-
-        val supportMapFrag = mapFrag?.childFragmentManager
-            ?.findFragmentById(R.id.google_map_container) as? SupportMapFragment
-
-        supportMapFrag?.getMapAsync { googleMap ->
-            val center = googleMap.cameraPosition.target
-            updateAddressFromMapCenter(center)
-        }
-    }
-
-    private fun enterSearchMode() {
-        binding.layoutRouteInputHeader.root.visibility = View.GONE
-
-        mainBinding?.mainToolbar?.visibility = View.VISIBLE
-        mainBinding?.mainBackIv?.visibility = View.VISIBLE
-
         if (::bottomSheetBehavior.isInitialized) {
             bottomSheetBehavior.isHideable = true
             bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN

--- a/app/src/main/res/layout/dialog_modal_case.xml
+++ b/app/src/main/res/layout/dialog_modal_case.xml
@@ -13,7 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="2026년 2월 20일 금요일"
-        android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+        android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
         style="@style/TextColor.Secondary"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"/>

--- a/app/src/main/res/layout/dialog_review.xml
+++ b/app/src/main/res/layout/dialog_review.xml
@@ -18,7 +18,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="잘 즐기고 계신가요?"
-        android:textAppearance="@style/TextAppearance.App.Num.BodyMd.Medium"
+        android:textAppearance="@style/TextAppearance.App.BodyMd.Medium"
         style="@style/TextColor.Setting"
         android:layout_marginTop="16dp"
         android:layout_marginStart="28dp"

--- a/app/src/main/res/layout/dialog_signout.xml
+++ b/app/src/main/res/layout/dialog_signout.xml
@@ -19,13 +19,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="정말 탈퇴하시겠습니까?"
-            android:textAppearance="@style/TextAppearance.App.Num.BodyMd.Medium"
+            android:textAppearance="@style/TextAppearance.App.BodyMd.Medium"
             style="@style/TextColor.Setting"/>
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="모든 데이터는 삭제됩니다"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             style="@style/TextColor.Setting"/>
     </LinearLayout>
     <LinearLayout

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/background">
     <LinearLayout
         android:id="@+id/home_add_schedule_ll"
         android:layout_width="match_parent"
@@ -35,7 +36,7 @@
     </LinearLayout>
     <LinearLayout
         android:visibility="gone"
-        android:id="@+id/home_background"
+        android:id="@+id/home_no_schedule"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
@@ -76,7 +77,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="2026년 2월"
-            android:textAppearance="@style/TextAppearance.App.Num.HeadlineLg"
+            android:textAppearance="@style/TextAppearance.App.HeadlineLg"
             android:textColor="@color/gray_900"
             android:gravity="center"
             style="@style/TextColor.Primary"/>

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -9,7 +9,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="캘린더"
-        android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Medium"
+        android:textAppearance="@style/TextAppearance.App.CaptionLg.Medium"
         android:layout_marginTop="29dp"
         android:layout_marginStart="23dp"
         app:layout_constraintTop_toTopOf="parent"
@@ -36,14 +36,14 @@
                 android:layout_height="wrap_content"
                 android:text="기본 캘린더"
                 android:layout_weight="1"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="19dp"/>
             <TextView
                 android:id="@+id/settings_calendar_default_tv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="내 캘린더"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginEnd="3dp"/>
             <ImageView
                 android:id="@+id/settings_calendar_default_iv"
@@ -71,7 +71,7 @@
                 android:layout_height="wrap_content"
                 android:text="캘린더 목록"
                 android:layout_weight="1"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="19dp"/>
             <ImageView
                 android:id="@+id/settings_calendar_list_iv"
@@ -88,7 +88,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="경로"
-        android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Medium"
+        android:textAppearance="@style/TextAppearance.App.CaptionLg.Medium"
         android:layout_marginTop="23dp"
         android:layout_marginStart="23dp"
         app:layout_constraintTop_toBottomOf="@id/settings_calendar_ll"
@@ -111,14 +111,14 @@
             android:layout_height="wrap_content"
             android:text="미리 출발"
             android:layout_weight="1"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             android:layout_marginStart="19dp"/>
         <TextView
             android:id="@+id/settings_route_minute_tv"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="10분"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             android:layout_marginEnd="3dp"/>
         <ImageView
             android:id="@+id/settings_route_minute_iv"
@@ -133,7 +133,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="알람"
-        android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Medium"
+        android:textAppearance="@style/TextAppearance.App.CaptionLg.Medium"
         android:layout_marginTop="25dp"
         android:layout_marginStart="23dp"
         app:layout_constraintTop_toBottomOf="@id/settings_route_ll"
@@ -160,14 +160,14 @@
                 android:layout_height="wrap_content"
                 android:text="리마인드 알림"
                 android:layout_weight="1"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="19dp"/>
             <TextView
                 android:id="@+id/settings_reminder_alarm_tv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="없음"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginEnd="3dp"/>
             <ImageView
                 android:id="@+id/settings_reminder_alarm_iv"
@@ -195,14 +195,14 @@
                 android:layout_height="wrap_content"
                 android:text="출발 알림"
                 android:layout_weight="1"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="19dp"/>
             <TextView
                 android:id="@+id/settings_departure_alarm_tv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="사용자 지정"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginEnd="3dp"/>
             <ImageView
                 android:id="@+id/settings_departure_alarm_iv"
@@ -219,7 +219,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="권한"
-        android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Medium"
+        android:textAppearance="@style/TextAppearance.App.CaptionLg.Medium"
         android:layout_marginTop="25dp"
         android:layout_marginStart="23dp"
         app:layout_constraintTop_toBottomOf="@id/settings_alarm_ll"
@@ -239,7 +239,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="알림 권한"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             style="@style/TextColor.Setting"
             android:layout_marginTop="17dp"
             android:layout_marginStart="19dp"/>
@@ -254,7 +254,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="위치 권한"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             style="@style/TextColor.Setting"
             android:layout_marginTop="13dp"
             android:layout_marginStart="19dp"/>
@@ -269,7 +269,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="캘린더 접근 권한"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             style="@style/TextColor.Setting"
             android:layout_marginTop="13dp"
             android:layout_marginStart="19dp"
@@ -304,7 +304,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="리뷰 남기기"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="8dp"/>
         </LinearLayout>
         <View
@@ -331,7 +331,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="로그아웃"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="6dp"/>
         </LinearLayout>
         <View
@@ -358,7 +358,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="탈퇴하기"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="9dp"/>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_sync_with_calendar.xml
+++ b/app/src/main/res/layout/fragment_sync_with_calendar.xml
@@ -23,7 +23,7 @@
             android:layout_height="wrap_content"
             android:text="내 휴대전화"
             android:layout_weight="1"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             android:layout_marginStart="19dp"/>
         <ImageView
             android:id="@+id/sync_my_phone_iv"
@@ -50,7 +50,7 @@
             android:layout_height="wrap_content"
             android:text="Google"
             android:layout_weight="1"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             android:layout_marginStart="19dp"/>
         <ImageView
             android:id="@+id/sync_google1_iv"
@@ -77,7 +77,7 @@
             android:layout_height="wrap_content"
             android:text="Google"
             android:layout_weight="1"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             android:layout_marginStart="19dp"/>
         <ImageView
             android:id="@+id/sync_google2_iv"
@@ -104,7 +104,7 @@
             android:layout_height="wrap_content"
             android:text="Samsung"
             android:layout_weight="1"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             android:layout_marginStart="19dp"/>
         <ImageView
             android:id="@+id/sync_samsung_iv"

--- a/app/src/main/res/layout/item_horizontal_calendar.xml
+++ b/app/src/main/res/layout/item_horizontal_calendar.xml
@@ -24,6 +24,6 @@
         android:paddingEnd="7dp"
         android:gravity="center"
         android:text="20"
-        android:textAppearance="@style/TextAppearance.App.Num.HeadlineMd"
+        android:textAppearance="@style/TextAppearance.App.HeadlineMd"
         android:textColor="@color/horizontal_calendar_date_color"/>
 </LinearLayout>

--- a/app/src/main/res/layout/item_modal.xml
+++ b/app/src/main/res/layout/item_modal.xml
@@ -46,7 +46,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="하루 종일"
-            android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+            android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
             style="@style/TextColor.Secondary"
             android:layout_marginStart="4dp" />
     </LinearLayout>
@@ -76,7 +76,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="장소1 --> 장소2"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 style="@style/TextColor.Primary"/>
         </LinearLayout>
         <LinearLayout
@@ -88,20 +88,20 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="00:00 - 00:00"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 style="@style/TextColor.Secondary"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="|"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="8dp"
                 style="@style/TextColor.Tertiary"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="0시간 0분"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="8dp"
                 style="@style/TextColor.Secondary"/>
         </LinearLayout>
@@ -151,7 +151,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="일정 알림"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 style="@style/TextColor.Secondary"/>
             <View
                 android:layout_width="0dp"
@@ -163,7 +163,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
                 android:text="10분 전, 1시간 전, ..."
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 style="@style/TextColor.Primary"/>
         </LinearLayout>
         <LinearLayout
@@ -181,7 +181,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="출발 알림"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 style="@style/TextColor.Secondary"/>
 
             <View
@@ -193,7 +193,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="5분 전, 15분 전, ..."
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 style="@style/TextColor.Primary"/>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_schedule.xml
+++ b/app/src/main/res/layout/item_schedule.xml
@@ -46,6 +46,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="8dp"
+        android:clickable="true"
         android:padding="12dp"
         android:background="@drawable/box_schedule">
         <LinearLayout
@@ -101,8 +102,8 @@
                 style="@style/TextColor.White"/>
             <CheckBox
                 android:id="@+id/schedule_checkbox"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="18dp"
+                android:layout_height="18dp"
                 android:button="@null"
                 android:background="@drawable/ic_schedule_checkbox"/>
         </LinearLayout>
@@ -124,7 +125,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="하루 종일"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 android:layout_marginStart="4dp"
                 style="@style/TextColor.Secondary"/>
             <View
@@ -164,7 +165,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="장소"
-                android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                 style="@style/TextColor.Secondary"/>
         </LinearLayout>
 
@@ -194,7 +195,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="4dp"
                     android:text="장소1 --> 장소2"
-                    android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                    android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                     style="@style/TextColor.Primary"/>
             </LinearLayout>
             <LinearLayout
@@ -206,20 +207,20 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="4dp"
                     android:text="00:00 - 00:00"
-                    android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                    android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                     style="@style/TextColor.Secondary"/>
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="|"
-                    android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                    android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                     android:layout_marginStart="8dp"
                     style="@style/TextColor.Tertiary"/>
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="0시간 0분"
-                    android:textAppearance="@style/TextAppearance.App.Num.CaptionLg.Regular"
+                    android:textAppearance="@style/TextAppearance.App.CaptionLg.Regular"
                     android:layout_marginStart="8dp"
                     style="@style/TextColor.Secondary"/>
             </LinearLayout>


### PR DESCRIPTION
- [REFACTOR]
# PR템플릿 

## 변경 사항 요약
- [x]  HomeFragment 배경 색 수정
- [x]  삭제 다이얼로그 이미지 수정
- [x]  item_schedule의 체크박스 사이즈 18dp로 수정
- [x]  Roboto 글꼴 적용 시 TextAppearnce에서 ‘Num’ 삭제
- [x]  아이템 개수가 없으면 기본 화면 띄우는 로직 작성
- [x]  스와이프 후 다른 곳 누르면 취소되는 로직 추가
   **- 현재 해당 일정의 topView(메인 콘텐츠 영역)를 클릭하면 취소하는 것으로 구현 → 이 방법이 불편하다면 클릭 범위 추후 수정
   - 현재는 임시로 어댑터에 swipeList를 만들어 스와이프 상태 관리 → 일정 데이터의 프로퍼티에서 다루도록 리팩토링 제안
   - 스와이프는 하나의 일정에서만 작동하도록 설정(여러 일정을 동시 스와이프 X)**

## 체크리스트
- [x] 코드 빌드 성공
- [x] 에뮬레이터 실행 시 성공

## 사진올리는곳
