### PR TITLE
[feat]네트워크 오류 다이얼로그 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-02-08T07:04:31.407272Z">
+        <DropdownSelection timestamp="2026-02-08T11:42:26.899517Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=R5CY11LZCPL" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R59N2058VDB" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/example/pace/ui/NetworkErrorDialog.kt
+++ b/app/src/main/java/com/example/pace/ui/NetworkErrorDialog.kt
@@ -1,0 +1,35 @@
+package com.example.pace.ui
+
+import android.app.Dialog
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.provider.Settings
+import com.example.pace.databinding.DialogNetworkErrorBinding
+
+class NetworkErrorDialog(
+    context: Context,
+    private val reload: () -> Unit
+    ): Dialog(context) {
+    private lateinit var binding: DialogNetworkErrorBinding
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DialogNetworkErrorBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.networkErrorWifiSettingBtn.setOnClickListener {
+            context.startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS))
+            dismiss()
+        }
+        binding.networkErrorReloadBtn.setOnClickListener {
+            reload()
+            dismiss()
+        }
+    }
+    override fun onStart() {
+        super.onStart()
+        window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+    }
+}

--- a/app/src/main/java/com/example/pace/ui/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/onboarding/OnboardingFragment.kt
@@ -1,14 +1,18 @@
 package com.example.pace.ui.onboarding
 
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.example.pace.databinding.FragmentOnboardingBinding
+import com.example.pace.ui.NetworkErrorDialog
 import com.example.pace.ui.main.MainActivity
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
@@ -77,8 +81,25 @@ class OnboardingFragment : Fragment() {
         binding.btnKakaoLogin.animate().alpha(1f).setDuration(500).start()
 
         binding.btnKakaoLogin.setOnClickListener {
-            loginWithKakao()
+            // 네트워크 연결 시에만 로그인 진행
+            val connectivityManager = getSystemService(requireContext(), ConnectivityManager:: class.java)
+            val activeNetwork = connectivityManager?.activeNetwork
+            val isActiveNetwork = connectivityManager?.getNetworkCapabilities(activeNetwork)
+            if(isActiveNetwork?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true){
+                loginWithKakao()
+            }else{
+                // 미연결 시 다이얼로그 띄우기
+                val dialog = NetworkErrorDialog(requireActivity()) {
+                    reload()
+                }
+                dialog.show()
+            }
         }
+    }
+
+    fun reload(){
+        parentFragmentManager.beginTransaction().detach(this).commit()
+        parentFragmentManager.beginTransaction().attach(this).commit()
     }
 
     private fun loginWithKakao() {

--- a/app/src/main/res/drawable/btn_network_error_green.xml
+++ b/app/src/main/res/drawable/btn_network_error_green.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="4dp"/>
+    <solid android:color="@color/semantic_info"/>
+</shape>

--- a/app/src/main/res/drawable/btn_network_error_white.xml
+++ b/app/src/main/res/drawable/btn_network_error_white.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="4dp"/>
+    <solid android:color="@color/white"/>
+    <stroke android:color="@color/gray_400" android:width="1dp"/>
+</shape>

--- a/app/src/main/res/layout/dialog_network_error.xml
+++ b/app/src/main/res/layout/dialog_network_error.xml
@@ -24,7 +24,8 @@
         android:gravity="center"
         android:layout_marginTop="8dp"
         app:layout_constraintTop_toBottomOf="@id/network_error_iv"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
     <TextView
         android:id="@+id/network_error_tv2"
         android:layout_width="match_parent"
@@ -34,19 +35,34 @@
         style="@style/TextColor.Primary"
         android:gravity="center"
         app:layout_constraintTop_toBottomOf="@id/network_error_tv1"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:gravity="center"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
         android:layout_marginTop="24dp"
         app:layout_constraintTop_toBottomOf="@id/network_error_tv2">
         <androidx.appcompat.widget.AppCompatButton
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:id="@+id/network_error_wifi_setting_btn"
+            android:layout_width="120dp"
+            android:layout_height="40dp"
             android:text="Wifi 설정"
             android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
-            style="@style/TextColor.Primary"/>
+            style="@style/TextColor.Primary"
+            android:background="@drawable/btn_network_error_white" />
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/network_error_reload_btn"
+            android:layout_width="120dp"
+            android:layout_height="40dp"
+            android:text="새로고침"
+            android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+            style="@style/TextColor.White"
+            android:background="@drawable/btn_network_error_green"
+            android:layout_marginStart="16dp"/>
     </LinearLayout>
 
 


### PR DESCRIPTION
# PR템플릿 

## 변경 사항 요약
- 피그마의 Network Error 다이얼로그 구현
- Wifi 설정 버튼 클릭 시 네트워크 설정으로 이동
- 새로고침 시 OnBoardingFragment 다시 로드
- 카카오 로그인 시에만 띄움

## 체크리스트
- [x] 코드 빌드 성공
- [x] 에뮬레이터 실행 시 성공

## 사진올리는곳
