### PR TITLE
[feat]local and remote schedulerepository 정리 및 데이터응답확인기본구조 작성

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
 
     // Retrofit 라이브러리
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
+
     // JSON 변환을 위한 Gson 컨버터
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
 
@@ -117,5 +118,9 @@ dependencies {
 
     // Kakao Login SDK
     implementation("com.kakao.sdk:v2-user:2.20.6")
+
+    // Retrofit 2.9.0과 호환되는 OkHttp & Logging Interceptor
+    implementation("com.squareup.okhttp3:okhttp:4.9.3")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.9.3")
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Pace"
-        tools:replace="android:theme">
+        tools:replace="android:theme"
+        android:networkSecurityConfig="@xml/network_security_config">
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${GOOGLE_API_KEY}" />

--- a/app/src/main/java/com/example/pace/PaceApplication.kt
+++ b/app/src/main/java/com/example/pace/PaceApplication.kt
@@ -2,14 +2,22 @@ package com.example.pace  // 최상위 패키지
 
 import android.app.Application
 import android.util.Log
+import com.example.pace.data.api.RetrofitClient
+import com.example.pace.data.datasource.AuthDataStore
 import com.example.pace.data.db.ScheduleDatabase
 import com.example.pace.data.datasource.NormalScheduleRemoteDataSource
 import com.example.pace.data.db.SearchDatabase
-import com.example.pace.data.repository.ScheduleRepository
+
 import com.kakao.sdk.common.KakaoSdk
 import com.example.pace.data.repository.SearchRepository
+import com.example.pace.data.repository.repository.ScheduleRepository
+import com.example.pace.data.repository.repositoryImpl.ScheduleRepositoryImpl
 
 class PaceApplication : Application() {
+    val authDataStore by lazy {
+        AuthDataStore(getSharedPreferences("pace_prefs", MODE_PRIVATE))
+    }
+
     lateinit var repository: ScheduleRepository
 
     val searchDatabase by lazy { SearchDatabase.getDatabase(this) }
@@ -22,16 +30,23 @@ class PaceApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
         try {
-            repository = ScheduleRepository(
-                ScheduleDatabase.getDatabase(this).scheduleDao(),  // ← DB 초기화 오류 확인
-                NormalScheduleRemoteDataSource(this),
-                this
+            // Retrofit 서비스 생성 (본인의 구조에 맞게)
+            val scheduleService = RetrofitClient.instance
+
+            // 2. 통합된 Impl 생성자 호출
+            repository = ScheduleRepositoryImpl(
+                api = scheduleService,
+                scheduleDao = ScheduleDatabase.getDatabase(this).scheduleDao(),
+                authDataStore = authDataStore,
+                normalScheduleDataSource = NormalScheduleRemoteDataSource(this),
+                context = this // Impl 생성자에서 @ApplicationContext Context를 받는 부분
             )
-            Log.d("PaceApplication", "Repository 초기화 완료")  // 로그 추가
+
+            Log.d("PaceApplication", "통합 Repository 초기화 완료")
         } catch (e: Exception) {
             Log.e("PaceApplication", "Repository 초기화 실패", e)
-            throw e  // 크래시로 디버깅
         }
 
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)

--- a/app/src/main/java/com/example/pace/data/api/RetrofitClient.kt
+++ b/app/src/main/java/com/example/pace/data/api/RetrofitClient.kt
@@ -1,0 +1,33 @@
+package com.example.pace.data.api
+
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object RetrofitClient {
+    // 본인의 서버 베이스 URL을 입력하세요.
+    private const val BASE_URL = "http://ec2-3-35-233-51.ap-northeast-2.compute.amazonaws.com:8080/"
+
+    private val okHttpClient: OkHttpClient by lazy {
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY // 통신 내용 전발을 로그로 찍음
+        }
+        OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .build()
+    }
+
+    private val retrofit: Retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create()) // JSON 파싱용
+            .build()
+    }
+
+    // PaceApplication에서 사용할 서비스 인스턴스
+    val instance: ScheduleService by lazy {
+        retrofit.create(ScheduleService::class.java)
+    }
+}

--- a/app/src/main/java/com/example/pace/data/datasource/AuthDataStore.kt
+++ b/app/src/main/java/com/example/pace/data/datasource/AuthDataStore.kt
@@ -21,5 +21,9 @@ class AuthDataStore(private val sharedPreferences: SharedPreferences) {
         }
     }
 
-    fun getAccessToken(): String? = sharedPreferences.getString("ACCESS_TOKEN", null)
+    fun getAccessToken(): String? {
+        // 실제 저장된 값이 없으니, 스웨거에서 성공했을 때 나온 Bearer ... 토큰을 직접 적어봅니다.
+        val tempToken = "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzY5NjE1Nzc4LCJleHAiOjE3NzA4MjUzNzgsInJvbGUiOiJST0xFX1VTRVIiLCJjYXRlZ29yeSI6ImFjY2VzcyJ9.b76UQaY4woR-H9mTU-1AopLCQckxeeamPpyNJRFYXFOxb5pZGcQGpKx3-RYO8rxnnnhFbc6UkQ0tlPX49O3oFg"
+        return tempToken
+    }
 }

--- a/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
@@ -1,5 +1,6 @@
 package com.example.pace.data.repository.repository
 
+import com.example.pace.data.model.Schedule
 import com.example.pace.data.model.request.CreateScheduleRequest
 import com.example.pace.data.model.request.DeleteScheduleRequest
 import com.example.pace.data.model.request.UpdateScheduleRequest
@@ -11,20 +12,19 @@ import com.example.pace.data.model.response.ScheduleConversionResponse
 import com.example.pace.data.model.response.ScheduleDetailResponse
 import com.example.pace.data.model.response.SchedulePagingResponse
 import com.example.pace.data.model.response.UpdateScheduleRouteResponse
-import retrofit2.http.Body
-import retrofit2.http.DELETE
-import retrofit2.http.GET
-import retrofit2.http.HTTP
-import retrofit2.http.Header
-import retrofit2.http.PATCH
-import retrofit2.http.POST
-import retrofit2.http.PUT
-import retrofit2.http.Path
-import retrofit2.http.Query
+import kotlinx.coroutines.flow.Flow
 
 interface ScheduleRepository {
 
+    // 원스톤 기능: 로컬 DB 감시
+    val allSchedules: Flow<List<Schedule>>
+    val calendarEvents: Flow<Unit>
 
+    // 원스톤 기능: 로컬 업데이트 및 동기화
+    suspend fun updateSchedule(schedule: Schedule)
+    suspend fun refreshSchedules()
+
+    //썽아 기능 (여기서부터)
     suspend fun updateScheduleRoute(
       accessToken: String,
         scheduleId: Long,

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
@@ -1,6 +1,12 @@
 package com.example.pace.data.repository.repositoryImpl
 
+import android.content.Context
 import com.example.pace.data.api.ScheduleService
+import com.example.pace.data.createCalendarObserver
+import com.example.pace.data.datasource.AuthDataStore
+import com.example.pace.data.datasource.NormalScheduleRemoteDataSource
+import com.example.pace.data.db.ScheduleDao
+import com.example.pace.data.model.Schedule
 import com.example.pace.data.model.request.CreateScheduleRequest
 import com.example.pace.data.model.request.DeleteScheduleRequest
 import com.example.pace.data.model.request.UpdateScheduleRequest
@@ -14,11 +20,107 @@ import com.example.pace.data.model.response.SchedulePagingResponse
 import com.example.pace.data.model.response.UpdateScheduleRouteResponse
 import com.example.pace.data.repository.repository.ScheduleRepository
 import com.example.pace.data.util.safeApiCall
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 class ScheduleRepositoryImpl @Inject constructor(
-    private val api : ScheduleService
+    private val api : ScheduleService, // 썽아
+    private val scheduleDao: ScheduleDao, //원스톤
+    private val normalScheduleDataSource: NormalScheduleRemoteDataSource, // 원스톤
+    private val authDataStore: AuthDataStore, // 썽아
+    @ApplicationContext private val context: Context
 ) : ScheduleRepository {
+
+    // 원스톤 로직
+    override val allSchedules: Flow<List<Schedule>> = scheduleDao.getAllSchedules().map { rawList ->
+        expandSchedules(rawList)
+    }
+
+    override val calendarEvents: Flow<Unit> = createCalendarObserver(context)
+
+    override suspend fun updateSchedule(schedule: Schedule) {
+        scheduleDao.updateSchedule(schedule)
+    }
+
+    /**
+     * Refreshes all schedules from all remote data sources and merges them
+     * with the local database, preserving local-only data like 'isPinned'.
+     */
+    override suspend fun refreshSchedules() {
+        // --- 1. Fetch from all remote sources ---
+        val normalSchedules = normalScheduleDataSource.getSchedules()
+        // TODO: Fetch from route data source when ready
+        // val routeSchedules = routeScheduleDataSource.getSchedules()
+
+        // For now, we only have normal schedules. In the future, combine lists here.
+        val allRemoteSchedules = normalSchedules
+
+        // --- 2. Fetch current local data ---
+        val localSchedules = scheduleDao.getAllSchedulesOnce()
+        val localScheduleMap = localSchedules.associateBy { it.id }
+
+        // --- 3. Perform Smart Merge ---
+        val mergedSchedules = allRemoteSchedules.map { remoteSchedule ->
+            val localSchedule = localScheduleMap[remoteSchedule.id]
+            if (localSchedule != null) {
+                // Preserve local-only data by merging
+                remoteSchedule.copy(isPinned = localSchedule.isPinned)
+            } else {
+                remoteSchedule
+            }
+        }
+
+        // --- 4. Identify and delete stale schedules ---
+        val remoteScheduleIds = allRemoteSchedules.map { it.id }.toSet()
+        val schedulesToDelete = localSchedules.filter { it.id !in remoteScheduleIds }
+
+        // --- 5. Update database ---
+        scheduleDao.deleteAll(schedulesToDelete)
+        scheduleDao.insertAll(mergedSchedules)
+    }
+
+    private fun expandSchedules(rawSchedules: List<Schedule>): List<Schedule> {
+        val expandedList = mutableListOf<Schedule>()
+        val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+        rawSchedules.forEach { schedule ->
+            val startLocalDate = LocalDate.parse(schedule.startDate, dateFormatter)
+            val endLocalDate = LocalDate.parse(schedule.endDate, dateFormatter)
+
+            // 1. 기간 일정 전개 (시작일 ~ 종료일 사이의 모든 날짜에 표시)
+            if (startLocalDate.isBefore(endLocalDate)) {
+                var current = startLocalDate
+                while (!current.isAfter(endLocalDate)) {
+                    expandedList.add(schedule.copy(startDate = current.format(dateFormatter)))
+                    current = current.plusDays(1)
+                }
+            }
+            // 2. 반복 일정 전개 (repeatRule이 있는 경우)
+            else if (!schedule.repeatRule.isNullOrEmpty()) {
+                // 간단한 매주(WEEKLY) 반복 예시 (필요에 따라 RRULE 파싱 라이브러리 사용 권장)
+                if (schedule.repeatRule!!.contains("WEEKLY")) {
+                    for (i in 0..24) { // 향후 약 6개월치 전개
+                        val repeatedDate = startLocalDate.plusWeeks(i.toLong())
+                        expandedList.add(schedule.copy(startDate = repeatedDate.format(dateFormatter)))
+                    }
+                } else {
+                    expandedList.add(schedule)
+                }
+            }
+            // 3. 일반 단일 일정
+            else {
+                expandedList.add(schedule)
+            }
+        }
+        return expandedList
+    }
+
+
+
     override suspend fun updateScheduleRoute(
         accessToken: String,
         scheduleId: Long,
@@ -41,7 +143,14 @@ class ScheduleRepositoryImpl @Inject constructor(
         lastDate: String?,
         lastId: Long?
     ): RawDefaultResponse<SchedulePagingResponse> {
-        return safeApiCall { api.getScheduleList(accessToken, startDate, endDate, lastDate, lastId) }
+        // 여기에 로그 추가!
+        android.util.Log.d("API_TEST", "getScheduleList 호출됨! 시작일: $startDate, 마지막ID: $lastId")
+
+        return safeApiCall {
+            val response = api.getScheduleList(accessToken, startDate, endDate, lastDate, lastId)
+            android.util.Log.d("API_TEST", "서버 응답 결과: $response") // 응답 성공 시 로그
+            response
+        }
     }
 
     override suspend fun createSchedule(

--- a/app/src/main/java/com/example/pace/module/NetworkModule.kt
+++ b/app/src/main/java/com/example/pace/module/NetworkModule.kt
@@ -4,6 +4,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Qualifier
@@ -20,9 +22,24 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideRetrofit(): Retrofit {
+    fun provideOkHttpClient(): OkHttpClient {
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+        return OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .build()
+    }
+
+
+    @Provides
+    @Singleton
+    @BaseRetrofit
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
             .baseUrl("http://ec2-3-35-233-51.ap-northeast-2.compute.amazonaws.com:8080/")
+            .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/app/src/main/java/com/example/pace/module/RepositoryModule.kt
+++ b/app/src/main/java/com/example/pace/module/RepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.example.pace.module
 
+import android.content.Context
 import com.example.pace.data.api.AuthControllerService
 import com.example.pace.data.api.MemberControllerService
 import com.example.pace.data.api.OnboardingService
@@ -8,6 +9,8 @@ import com.example.pace.data.api.SavedPlaceService
 import com.example.pace.data.api.ScheduleService
 import com.example.pace.data.api.SettingsService
 import com.example.pace.data.datasource.AuthDataStore
+import com.example.pace.data.datasource.NormalScheduleRemoteDataSource
+import com.example.pace.data.db.ScheduleDao
 import com.example.pace.data.repository.repository.AuthControllerRepository
 import com.example.pace.data.repository.repository.MemberControllerRepository
 import com.example.pace.data.repository.repository.OnboardingRepository
@@ -27,6 +30,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ViewModelScoped
 
 @Module
@@ -67,9 +71,19 @@ object RepositoryModule {
     @ViewModelScoped
     @Provides
     fun providesScheduleRepository(
-        ScheduleService: ScheduleService
-    ) : ScheduleRepository {
-        return ScheduleRepositoryImpl(ScheduleService)
+        scheduleService: ScheduleService,
+        scheduleDao: ScheduleDao,
+        authDataStore: AuthDataStore,
+        normalScheduleDataSource: NormalScheduleRemoteDataSource,
+        @ApplicationContext context: Context
+    ): ScheduleRepository {
+        return ScheduleRepositoryImpl(
+            api = scheduleService,
+            scheduleDao = scheduleDao,
+            authDataStore = authDataStore,
+            normalScheduleDataSource = normalScheduleDataSource,
+            context = context
+        )
     }
 
     @ViewModelScoped

--- a/app/src/main/java/com/example/pace/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/pace/ui/main/MainActivity.kt
@@ -31,9 +31,9 @@ import androidx.activity.viewModels
 import com.example.pace.PaceApplication
 import com.example.pace.data.db.ScheduleDatabase
 import com.example.pace.data.datasource.NormalScheduleRemoteDataSource
-import com.example.pace.data.repository.ScheduleRepository
 import com.example.pace.ui.main.calendar.ScheduleViewModel
 import com.example.pace.ui.main.calendar.ScheduleViewModelFactory
+import com.example.pace.data.repository.repository.ScheduleRepository
 
 class MainActivity : AppCompatActivity() {
     lateinit var binding: ActivityMainBinding
@@ -42,7 +42,11 @@ class MainActivity : AppCompatActivity() {
     // ViewModel injection
     private val repository by lazy { (application as PaceApplication).repository }
     private val viewModel: ScheduleViewModel by viewModels {
-        ScheduleViewModelFactory((application as PaceApplication).repository)
+        val app = application as PaceApplication
+        ScheduleViewModelFactory(
+            repository = app.repository,
+            authDataStore = app.authDataStore
+        )
     }
 
     fun getSharedViewModel(): ScheduleViewModel = viewModel
@@ -159,6 +163,7 @@ class MainActivity : AppCompatActivity() {
         } else {
             android.util.Log.d("MainActivity", "onResume: 여전히 권한 없음, 스킵")
         }
+
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleViewModel.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleViewModel.kt
@@ -1,9 +1,11 @@
 package com.example.pace.ui.main.calendar
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.pace.data.datasource.AuthDataStore
 import com.example.pace.data.model.Schedule
-import com.example.pace.data.repository.ScheduleRepository
+import com.example.pace.data.repository.repository.ScheduleRepository
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -11,8 +13,12 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import javax.inject.Inject
 
-class ScheduleViewModel(private val repository: ScheduleRepository) : ViewModel() {
+class ScheduleViewModel @Inject constructor(
+    private val repository: ScheduleRepository,
+    private val authDataStore: AuthDataStore
+) : ViewModel() {
 
     private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
@@ -39,8 +45,25 @@ class ScheduleViewModel(private val repository: ScheduleRepository) : ViewModel(
     }
 
     fun refreshSchedules() {
+        android.util.Log.d("API_TEST", "ViewModel: refreshSchedules() 진입")
+
         viewModelScope.launch {
-            repository.refreshSchedules()
+            try {
+                // 2. AuthDataStore에서 저장된 토큰을 가져옵니다.
+                val token = authDataStore.getAccessToken()
+                Log.d("API_TEST", "ViewModel: 불러온 토큰 -> $token")
+
+                if (token != null) {
+                    // 3. 불러온 토큰을 사용하여 API 호출
+                    val response = repository.getScheduleList(token,"2026-02-01","2026-02-28",null,null)
+                    Log.d("API_TEST", "ViewModel: 리포지토리 호출 완료 -> $response")
+                } else {
+                    Log.e("API_TEST", "ViewModel: 저장된 토큰이 없습니다. 로그인이 필요합니다.")
+                }
+
+            } catch (e: Exception) {
+                Log.e("API_TEST", "ViewModel: 에러 발생 -> ${e.message}")
+            }
         }
     }
 

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleViewModelFactory.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleViewModelFactory.kt
@@ -2,13 +2,17 @@ package com.example.pace.ui.main.calendar
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.example.pace.data.repository.ScheduleRepository
+import com.example.pace.data.datasource.AuthDataStore
+import com.example.pace.data.repository.repository.ScheduleRepository
 
-class ScheduleViewModelFactory(private val repository: ScheduleRepository) : ViewModelProvider.Factory {
+class ScheduleViewModelFactory(
+    private val repository: ScheduleRepository,
+    private val authDataStore: AuthDataStore
+) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(ScheduleViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return ScheduleViewModel(repository) as T
+            return ScheduleViewModel(repository,authDataStore) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/example/pace/ui/onboarding/CalendarSelectFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/onboarding/CalendarSelectFragment.kt
@@ -52,8 +52,8 @@ class CalendarSelectFragment : Fragment() {
         }
 
         binding.tvDescription.setBoldText(
-            "출발 알림을 언제 보내 드릴까요?",
-            listOf("출발 알림")
+            "어떤 캘린더에 일정을 담아 드릴까요?",
+            listOf("어떤 캘린더")
         )
     }
 

--- a/app/src/main/java/com/example/pace/ui/onboarding/DepartAlarmFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/onboarding/DepartAlarmFragment.kt
@@ -50,8 +50,8 @@ class DepartAlarmFragment : Fragment() {
         }
 
         binding.tvDescription.setBoldText(
-            "어떤 캘린더에 일정을 담아 드릴까요?",
-            listOf("어떤 캘린더")
+            "출발 알림을 언제 보내 드릴까요?",
+            listOf("출발 알람")
         )
     }
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">ec2-3-35-233-51.ap-northeast-2.compute.amazonaws.com</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
- [FEAT]
# PR템플릿 

## 변경 사항 요약
- 변경사항 요약본 작성
원스톤의 스케줄레포지토리와 제가 만든 스케줄 레포지토리를 합치고, 서비스, 레트로핏, 모듈들 수정
응답확인이 가능하게 기본구조를 작성

## 체크리스트
- [x] 코드 빌드 성공
- [x] 에뮬레이터 실행 시 성공

## 사진올리는곳
<img width="1868" height="445" alt="image" src="https://github.com/user-attachments/assets/e5cf1782-4d81-4f1d-b6da-70ece2ace0ec" />
응답이 일어나는 모습