### PR TITLE
[Feat]: 반복 로직 작성완료, 선택한 캘린더 일정들만 보여주기

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-02-11T11:52:15.546102Z">
+        <DropdownSelection timestamp="2026-02-14T12:35:10.653062200Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/li-dianne/.android/avd/Pixel_6.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\sshhs\.android\avd\Pixel_7.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,16 +59,17 @@
         <activity
             android:name=".ui.splash.SplashActivity"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
         </activity>
 
         <activity
             android:name=".ui.main.MainActivity"
-            android:exported="true"
+            android:exported="false"
             android:windowSoftInputMode="adjustNothing">
+
         </activity>
 
         <activity android:name=".ui.settings.SettingsActivity"

--- a/app/src/main/java/com/example/pace/data/api/SettingsService.kt
+++ b/app/src/main/java/com/example/pace/data/api/SettingsService.kt
@@ -16,7 +16,6 @@ interface SettingsService {
         @Header("Authorization") accessToken: String,
     ): RawDefaultResponse<MemberSettingsResponse>
 
-    // 1. @POST에서 @PATCH로 변경
     @PATCH("/api/v1/member/settings")
     suspend fun updateMemberSettings(
         @Header("Authorization") accessToken: String,

--- a/app/src/main/java/com/example/pace/data/datasource/NormalScheduleRemoteDataSource.kt
+++ b/app/src/main/java/com/example/pace/data/datasource/NormalScheduleRemoteDataSource.kt
@@ -17,7 +17,6 @@ import javax.inject.Inject // 추가
 class NormalScheduleRemoteDataSource @Inject constructor(
     @ApplicationContext private val applicationContext: Context
 ) {
-
     suspend fun insertToCalendarProvider(
         request: CreateScheduleRequest,
         selectedCalendarId: Long? = null,
@@ -25,42 +24,38 @@ class NormalScheduleRemoteDataSource @Inject constructor(
     ): Long = withContext(Dispatchers.IO) {
         val contentResolver = applicationContext.contentResolver
 
-        // 1. 시간 계산
         val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
         val startMillis = sdf.parse("${request.startDate} ${request.startTime ?: "00:00"}")?.time ?: System.currentTimeMillis()
         val endMillis = sdf.parse("${request.endDate} ${request.endTime ?: "23:59"}")?.time ?: (startMillis + 3600000)
 
-        // 2. 반복 규칙 생성 (중복 호출 방지)
         val generatedRrule = buildRRule(request.repeatInfo)
-
-        // [로그 추가] 시스템에 들어가기 직전 데이터 확인
-        Log.d("CALENDAR_INSERT", "=== 시스템 삽입 시도 ===")
-        Log.d("CALENDAR_INSERT", "ID: $selectedCalendarId, Color: $selectedColor, RRULE: $generatedRrule")
 
         val values = ContentValues().apply {
             put(CalendarContract.Events.TITLE, request.title)
             put(CalendarContract.Events.DESCRIPTION, request.memo)
             put(CalendarContract.Events.EVENT_LOCATION, request.place?.targetName ?: "")
             put(CalendarContract.Events.DTSTART, startMillis)
-            put(CalendarContract.Events.DTEND, endMillis)
             put(CalendarContract.Events.ALL_DAY, if (request.isAllDay) 1 else 0)
-
-            // 중요: 캘린더 ID가 1L이면 기본 로컬 캘린더일 확률이 높으며, 색상 변경을 제한할 수 있습니다.
             put(CalendarContract.Events.CALENDAR_ID, selectedCalendarId ?: 1L)
             put(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
 
-            // [색상 적용]
-            // selectedColor가 0이거나 null이면 기본색 사용
-            val finalColor = if (selectedColor != null && selectedColor != 0) {
-                selectedColor
-            } else {
-                android.graphics.Color.parseColor("#DC354B")
-            }
+            // [색상 처리]
+            val finalColor = if (selectedColor != null && selectedColor != 0) selectedColor
+            else android.graphics.Color.parseColor("#DC354B")
             put(CalendarContract.Events.EVENT_COLOR, finalColor)
 
-            // [반복 설정 적용]
+            // [핵심 보완: 반복 일정일 경우 DURATION 처리]
             if (!generatedRrule.isNullOrEmpty()) {
                 put(CalendarContract.Events.RRULE, generatedRrule)
+
+                // 반복 일정은 DTEND 대신 DURATION 사용 권장 (P3600S = 3600초 = 1시간)
+                val durationSeconds = (endMillis - startMillis) / 1000
+                put(CalendarContract.Events.DURATION, "P${durationSeconds}S")
+                // 반복 일정 시 DTEND는 null로 비워두는 것이 표준입니다.
+                putNull(CalendarContract.Events.DTEND)
+            } else {
+                // 반복이 아닐 때는 일반적인 DTEND 사용
+                put(CalendarContract.Events.DTEND, endMillis)
             }
 
             put(CalendarContract.Events.HAS_ALARM, if (request.reminders.isNotEmpty()) 1 else 0)
@@ -279,19 +274,27 @@ class NormalScheduleRemoteDataSource @Inject constructor(
 
     // rrule에 맞춰서 변환
     private fun buildRRule(info: RepeatInfo?): String? {
-        if (info == null) return null // 여기서 null이면 반복이 안 됩니다.
-        Log.d("CALENDAR_INSERT", "buildRRule 내부 진입: $info")
+        if (info == null || info.repeatType.uppercase() == "NONE") return null
 
         return try {
             val rrule = StringBuilder("FREQ=${info.repeatType.uppercase()}")
-            if (info.repeatInterval > 0) rrule.append(";INTERVAL=${info.repeatInterval}")
+            if (info.repeatInterval > 1) rrule.append(";INTERVAL=${info.repeatInterval}")
 
             if (!info.daysOfWeek.isNullOrEmpty()) {
-                // 요일 형식이 "MONDAY"면 "MO"로, "MON"이면 "MO"로 변환 필요
-                val systemDays = info.daysOfWeek.split(",")
-                    .map { it.trim().take(2).uppercase() }
-                    .joinToString(",")
-                rrule.append(";BYDAY=$systemDays")
+                val days = info.daysOfWeek.split(",")
+                    .mapNotNull { day ->
+                        when (day.trim().uppercase()) {
+                            "SUNDAY", "SUN", "SU" -> "SU"
+                            "MONDAY", "MON", "MO" -> "MO"
+                            "TUESDAY", "TUE", "TU" -> "TU"
+                            "WEDNESDAY", "WED", "WE" -> "WE"
+                            "THURSDAY", "THU", "TH" -> "TH"
+                            "FRIDAY", "FRI", "FR" -> "FR"
+                            "SATURDAY", "SAT", "SA" -> "SA"
+                            else -> null
+                        }
+                    }.joinToString(",")
+                if (days.isNotEmpty()) rrule.append(";BYDAY=$days")
             }
 
             if (info.endType.uppercase() == "COUNT") {
@@ -301,12 +304,7 @@ class NormalScheduleRemoteDataSource @Inject constructor(
                 rrule.append(";UNTIL=${untilDate}T235959Z")
             }
 
-            val result = rrule.toString()
-            Log.d("CALENDAR_INSERT", "생성된 최종 문자열: $result")
-            result
-        } catch (e: Exception) {
-            Log.e("CALENDAR_INSERT", "buildRRule 에러: ${e.message}")
-            null
-        }
+            rrule.toString()
+        } catch (e: Exception) { null }
     }
 }

--- a/app/src/main/java/com/example/pace/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/example/pace/data/db/AppDatabase.kt
@@ -1,15 +1,35 @@
 package com.example.pace.data.db
 
+import android.content.Context
 import androidx.room.Database
+import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.example.pace.data.converter.Converters
 import com.example.pace.data.model.UserSettingsEntity
 
-@Database(entities = [UserSettingsEntity::class], version = 1)
-@TypeConverters(Converters::class) // 아까 만든 컨버터 등록
+@Database(entities = [UserSettingsEntity::class], version = 1, exportSchema = false)
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
+
     abstract fun userSettingsDao(): UserSettingsDao
 
-    // 싱글톤 패턴으로 구현하는 것이 일반적입니다. (Hilt 미사용 시)
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        fun getDatabase(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "app_database" // 파일 이름도 구분되게 설정
+                )
+                    .fallbackToDestructiveMigration() // 버전 충돌 시 초기화 (개발 단계에서 유용)
+                    .build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/pace/data/model/UserSetting.kt
+++ b/app/src/main/java/com/example/pace/data/model/UserSetting.kt
@@ -2,22 +2,42 @@ package com.example.pace.data.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.example.pace.data.model.request.AlarmSettingRequest
+import com.example.pace.data.model.request.UpdateSettingsRequest
 
 @Entity(tableName = "user_settings")
 data class UserSettingsEntity(
     @PrimaryKey val id: Long = 1L,
     val isReminderActive: Boolean,
     val earlyArrivalTime: Int,
-
-    // [기본 캘린더] 하나만 선택 (RadioGroup/RadioButton용)
     val calendarId: Long,
-
-    // [동기화할 캘린더들] 다중 선택 (RecyclerView/Toggle용) 👈 추가됨
     val syncedCalendarIds: List<Long> = emptyList(),
-
     val departureAlarms: List<Int>,
     val scheduleAlarms: List<Int>,
-
     val isSynced: Boolean = false,
     val lastUpdated: Long = System.currentTimeMillis()
 )
+
+// 💡 클래스 괄호 밖 하단에 추가하세요.
+fun UserSettingsEntity.toUpdateRequest(): UpdateSettingsRequest {
+    // 알람 리스트 생성 로직
+    val alarmList = mutableListOf<AlarmSettingRequest>()
+
+    // 비어있지 않을 때만 추가하거나, 빈 리스트라도 타입을 명시해서 추가
+    alarmList.add(AlarmSettingRequest(type = "DEPARTURE", minutes = this.departureAlarms))
+    alarmList.add(AlarmSettingRequest(type = "SCHEDULE", minutes = this.scheduleAlarms))
+
+    return UpdateSettingsRequest(
+        isReminderActive = this.isReminderActive,
+        earlyArrivalTime = this.earlyArrivalTime,
+        calendarType = this.calendarId.toString(), // 👈 Long을 String으로 변환
+        alarms = alarmList,
+
+//        // 서버 DTO의 나머지 필드들 (필요에 따라 매핑)
+//        isNotiEnabled = true,
+//        isLocEnabled = true,
+//        reminderTimes = emptyList(), // 필요시 추가
+//        scheduleReminderTimes = this.scheduleAlarms,
+//        departureReminderTimes = this.departureAlarms
+    )
+}

--- a/app/src/main/java/com/example/pace/data/model/request/ScheduleRequest.kt
+++ b/app/src/main/java/com/example/pace/data/model/request/ScheduleRequest.kt
@@ -46,14 +46,17 @@ data class CreateScheduleRequest(
     @SerializedName("color") val color: String? = "#DC354B"
 )
 data class RepeatInfo(
-    @SerializedName("repeatType") val repeatType: String,
-    @SerializedName("repeatInterval") val repeatInterval: Int,
-    @SerializedName("daysOfWeek") val daysOfWeek: String?,
-    @SerializedName("endType") val endType: String,
-    @SerializedName("endCount") val endCount: Int,
-    @SerializedName("repeatEndDate") val repeatEndDate: String?
-): java.io.Serializable
+    @SerializedName("repeatType") val repeatType: String,      // DAILY, WEEKLY, MONTHLY, YEARLY, NONE
+    @SerializedName("repeatInterval") val repeatInterval: Int = 1,
+    @SerializedName("daysOfWeek") val daysOfWeek: String? = null, // "MO,WE,FR"
+    @SerializedName("endType") val endType: String,            // NEVER, COUNT, DATE
+    @SerializedName("endCount") val endCount: Int? = null,     // endType이 COUNT일 때만 사용
+    @SerializedName("repeatEndDate") val repeatEndDate: String? = null // endType이 DATE일 때만 사용
+): java.io.Serializable {
 
+    // 유틸리티 함수: RRULE 생성 시 불필요한 값 제거용
+    fun isValid(): Boolean = repeatType.uppercase() != "NONE"
+}
 data class PlaceRequest(
     @SerializedName("targetName") val targetName: String,
     @SerializedName("targetLat") val targetLat: Double,

--- a/app/src/main/java/com/example/pace/data/model/request/UpdateSettingRequest.kt
+++ b/app/src/main/java/com/example/pace/data/model/request/UpdateSettingRequest.kt
@@ -3,29 +3,22 @@ package com.example.pace.data.model.request
 import com.google.gson.annotations.SerializedName
 
 data class UpdateSettingsRequest(
-    @SerializedName("earlyArrivalTime")
-    val earlyArrivalTime: Int,
-    @SerializedName("isNotiEnabled")
-    val isNotiEnabled: Boolean,
-    @SerializedName("isLocEnabled")
-    val isLocEnabled: Boolean,
     @SerializedName("isReminderActive")
     val isReminderActive: Boolean,
-    @SerializedName("CalendarType")
+
+    @SerializedName("earlyArrivalTime")
+    val earlyArrivalTime: Int,
+
+    @SerializedName("calendarType") // 대소문자 주의 (스웨거 기준 소문자 c)
     val calendarType: String,
-    @SerializedName("reminderTimes")
-    val reminderTimes: List<Int>,
-    @SerializedName("scheduleReminderTimes")
-    val scheduleReminderTimes: List<Int>,
-    @SerializedName("departureReminderTimes")
-    val departureReminderTimes: List<Int>,
+
     @SerializedName("alarms")
-    val alarms: List<AlarmSetting>
+    val alarms: List<AlarmSettingRequest>
 )
 
-data class AlarmSetting(
+data class AlarmSettingRequest(
     @SerializedName("type")
-    val type: String,
+    val type: String, // "SCHEDULE" 또는 "DEPARTURE"
     @SerializedName("minutes")
     val minutes: List<Int>
 )

--- a/app/src/main/java/com/example/pace/data/model/response/UpdateSettingsResponse.kt
+++ b/app/src/main/java/com/example/pace/data/model/response/UpdateSettingsResponse.kt
@@ -2,25 +2,32 @@ package com.example.pace.data.model.response
 
 import com.google.gson.annotations.SerializedName
 
+// 1. 최상위 응답 객체
 data class UpdateSettingsResponse(
-    @SerializedName("memberId") // 스웨거에 memberId가 있다면 반드시 추가!
-    val memberId: Long,
-    @SerializedName("earlyArrivalTime")
-    val earlyArrivalTime: Int,
-    @SerializedName("isNotiEnabled")
-    val isNotiEnabled: Boolean,
-    @SerializedName("isLocEnabled")
-    val isLocEnabled: Boolean,
+    @SerializedName("isSuccess")
+    val isSuccess: Boolean,
+
+    @SerializedName("code")
+    val code: String,
+
+    @SerializedName("message")
+    val message: String,
+
+    @SerializedName("result")
+    val result: SettingsResult // 실제 데이터는 이 안에 있음
+)
+
+// 2. "result" 내부에 담긴 데이터 객체
+data class SettingsResult(
     @SerializedName("isReminderActive")
     val isReminderActive: Boolean,
+
+    @SerializedName("earlyArrivalTime")
+    val earlyArrivalTime: Int,
+
     @SerializedName("calendarType")
     val calendarType: String,
-    @SerializedName("reminderTimes")
-    val reminderTimes: List<Int>,
-    @SerializedName("scheduleReminderTimes")
-    val scheduleReminderTimes: List<Int>,
-    @SerializedName("departureReminderTimes")
-    val departureReminderTimes: List<Int>,
+
     @SerializedName("alarms")
     val alarms: List<AlarmSettingResponse>
 )

--- a/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
@@ -16,14 +16,21 @@ interface ScheduleRepository {
     fun getUsedColors(): Flow<List<String>>
     fun getCalendarName(calendarId: Long): String?
 
-    suspend fun searchSchedules(query: String, colors: Set<String>, includeRoute: Boolean, startDate: String, endDate: String): List<Schedule>
+    suspend fun searchSchedules(
+        query: String,
+        colors: Set<String>,
+        includeRoute: Boolean,
+        startDate: String,
+        endDate: String,
+        selectedIds: List<Long> // 추가됨
+    ): List<Schedule>
 
     suspend fun createSchedule(
         accessToken: String?,
         request: CreateScheduleRequest,
-        placeId: String?,
-        calendarId: Long?,
-        selectedColor: Int?
+        placeId: String? = null,
+        calendarId: Long? = null,
+        selectedColor: Int? = null
     ): RawDefaultResponse<CreateScheduleResponse>
 
     // 서버 API 관련

--- a/app/src/main/java/com/example/pace/data/repository/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repository/SettingsRepository.kt
@@ -17,6 +17,8 @@ interface SettingsRepository {
         request: UpdateSettingsRequest
     ):RawDefaultResponse<UpdateSettingsResponse>
 
-    suspend fun updateSettings(settings: UserSettingsEntity)
-    fun getUserSettings(): kotlinx.coroutines.flow.Flow<UserSettingsEntity?>
+    suspend fun updateSettings(accessToken: String, settings: UserSettingsEntity)
+    fun getUserSettings(): Flow<UserSettingsEntity?>
+
+    suspend fun updateSettingsLocally(settings: UserSettingsEntity)
 }

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
@@ -178,14 +178,33 @@ class ScheduleRepositoryImpl @Inject constructor(
         api.convertRouteToGeneral(accessToken, id)
     }
 
-    override suspend fun searchSchedules(query: String, colors: Set<String>, includeRoute: Boolean, startDate: String, endDate: String): List<Schedule> {
+    override suspend fun searchSchedules(
+        query: String,
+        colors: Set<String>,
+        includeRoute: Boolean,
+        startDate: String,
+        endDate: String,
+        selectedIds: List<Long> // ViewModel에서 넘겨받은 값
+    ): List<Schedule> {
         val raw = scheduleDao.searchSchedulesWithRange("%$query%", startDate, endDate)
+
         return expandSchedules(raw).filter { schedule ->
+            // 1. 캘린더 필터링 (백엔드 일정은 통과, 일반 일정만 체크)
+            val calendarMatch = if (schedule.type == "ROUTE") {
+                true // 💡 백엔드(경로) 일정은 필터링을 걸지 않음
+            } else {
+                // 일반 일정은 선택된 리스트에 있거나, 리스트가 비어있을 때만 노출
+                selectedIds.isEmpty() || selectedIds.contains(schedule.calendarId)
+            }
+
+            // 2. 기존 필터링 로직 (색상, 경로 포함 여부)
             val sColor = schedule.eventColor?.toString() ?: ""
             val cColor = schedule.calendarColor?.toString() ?: ""
             val colorMatch = colors.isEmpty() || colors.any { it.equals(sColor, true) || it.equals(cColor, true) }
             val routeMatch = includeRoute || schedule.type != "ROUTE"
-            colorMatch && routeMatch
+
+            // 💡 모든 조건 결합
+            calendarMatch && colorMatch && routeMatch
         }
     }
 
@@ -353,15 +372,43 @@ class ScheduleRepositoryImpl @Inject constructor(
 
     private fun parseRecurrenceString(rruleStr: String): Recurrence? {
         return try {
-            val parts = rruleStr.split(";")
+            val cleanRrule = rruleStr.replace("RRULE:", "").trim()
+            val parts = cleanRrule.split(";")
             val params = parts.associate {
                 val split = it.split("=")
                 if (split.size == 2) split[0].uppercase() to split[1] else "" to ""
             }
+
             val freqStr = params["FREQ"] ?: return null
             val builder = Recurrence.Builder(Frequency.valueOf(freqStr))
+
             params["INTERVAL"]?.toIntOrNull()?.let { builder.interval(it) }
             params["COUNT"]?.toIntOrNull()?.let { builder.count(it) }
+
+            // UNTIL(날짜 종료) 파싱 부분 수정
+            params["UNTIL"]?.let { untilStr ->
+                try {
+                    // 1. format 결정 (if-else 식을 명확히 정의)
+                    val format = if (untilStr.contains("T")) {
+                        SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.getDefault()).apply {
+                            timeZone = TimeZone.getTimeZone("UTC")
+                        }
+                    } else {
+                        SimpleDateFormat("yyyyMMdd", Locale.getDefault())
+                    }
+
+                    // 2. 파싱 및 적용
+                    val date = format.parse(untilStr)
+                    if (date != null) {
+                        builder.until(ICalDate(date, untilStr.contains("T")))
+                    } else{
+
+                    }
+                } catch (e: Exception) {
+                    Log.e("RRULE_PARSE", "UNTIL 파싱 실패: $untilStr", e)
+                }
+            }
+
             params["BYDAY"]?.let { byDayStr ->
                 byDayStr.split(",").forEach { dayCode ->
                     val dayOfWeek = when(dayCode.takeLast(2)) {
@@ -436,30 +483,61 @@ class ScheduleRepositoryImpl @Inject constructor(
     }
 
     private fun buildRRuleFromRequest(info: RepeatInfo?): String? {
-        android.util.Log.d("RRULE_DEBUG", "전달받은 info: $info")
+        // 1. 반복 정보가 없으면 즉시 null 반환 (Statement로서의 return)
+        if (info == null || info.repeatType.uppercase() == "NONE") return null
 
-        if (info == null) {
-            android.util.Log.d("RRULE_DEBUG", "info가 null이라 종료합니다.")
-            return null
-        }
         return try {
             val rrule = StringBuilder("FREQ=${info.repeatType.uppercase()}")
-            if (info.repeatInterval > 1) rrule.append(";INTERVAL=${info.repeatInterval}")
+
+            // 1. 간격
+            if (info.repeatInterval > 1) {
+                rrule.append(";INTERVAL=${info.repeatInterval}")
+            }
+
+            // 2. 요일
             if (!info.daysOfWeek.isNullOrEmpty()) {
-                // "MON,TUE" -> "MO,TU"
                 val days = info.daysOfWeek.split(",")
-                    .map { it.trim().take(2).uppercase() }
-                    .joinToString(",")
-                rrule.append(";BYDAY=$days")
+                    .mapNotNull { day ->
+                        when (day.trim().uppercase()) {
+                            "SUNDAY", "SUN", "SU" -> "SU"
+                            "MONDAY", "MON", "MO" -> "MO"
+                            "TUESDAY", "TUE", "TU" -> "TU"
+                            "WEDNESDAY", "WED", "WE" -> "WE"
+                            "THURSDAY", "THU", "TH" -> "TH"
+                            "FRIDAY", "FRI", "FR" -> "FR"
+                            "SATURDAY", "SAT", "SA" -> "SA"
+                            else -> null
+                        }
+                    }.joinToString(",")
+                if (days.isNotEmpty()) {
+                    rrule.append(";BYDAY=$days")
+                }
             }
-            if (info.endType.uppercase() == "COUNT") {
-                rrule.append(";COUNT=${info.endCount}")
-            } else if (info.endType.uppercase() == "DATE" && !info.repeatEndDate.isNullOrEmpty()) {
-                val untilDate = info.repeatEndDate.replace("-", "")
-                rrule.append(";UNTIL=${untilDate}T235959Z")
+
+            // 3. 종료 조건 (when 문을 식이 아닌 문장으로 사용)
+            when (info.endType.uppercase()) {
+                "COUNT" -> {
+                    val count = info.endCount
+                    if (count != null && count > 0) {
+                        rrule.append(";COUNT=$count")
+                    }
+                }
+                "DATE" -> {
+                    val endDate = info.repeatEndDate
+                    if (!endDate.isNullOrEmpty()) {
+                        val untilDate = endDate.replace("-", "")
+                        rrule.append(";UNTIL=${untilDate}T235959Z")
+                    }
+                }
+                else -> {
+                    // 아무것도 하지 않음 (무한 반복)
+                }
             }
+
+            // 최종 문자열 반환
             rrule.toString()
         } catch (e: Exception) {
+            Log.e("RRULE_ERROR", "RRULE 생성 실패: ${e.message}")
             null
         }
     }

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/SettingsRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.example.pace.data.repository.repositoryImpl
 
-import javax.inject.Inject
+import android.content.Context
+import android.util.Log
+import androidx.work.*
 import com.example.pace.data.api.SettingsService
 import com.example.pace.data.db.UserSettingsDao
 import com.example.pace.data.model.UserSettingsEntity
@@ -8,13 +10,21 @@ import com.example.pace.data.model.request.UpdateSettingsRequest
 import com.example.pace.data.model.response.MemberSettingsResponse
 import com.example.pace.data.model.response.RawDefaultResponse
 import com.example.pace.data.model.response.UpdateSettingsResponse
+import com.example.pace.data.model.toUpdateRequest
 import com.example.pace.data.repository.repository.SettingsRepository
 import com.example.pace.data.util.safeApiCall
+import com.example.pace.data.worker.SyncSettingsWorker
+import dagger.hilt.android.qualifiers.ApplicationContext // 💡 Import 추가 확인
 import kotlinx.coroutines.flow.Flow
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
 class SettingsRepositoryImpl @Inject constructor(
-    private val dao: UserSettingsDao, // Room DAO 주입
-    private val api: SettingsService // Retrofit 서비스 주입 (이름은 프로젝트마다 다를 수 있음)
+    private val dao: UserSettingsDao,
+    private val api: SettingsService,
+    @ApplicationContext private val context: Context // 💡 여기에 context 주입을 추가하세요!
 ) : SettingsRepository {
+
     override suspend fun getMemberSettings(
         accessToken: String,
     ): RawDefaultResponse<MemberSettingsResponse> {
@@ -28,12 +38,63 @@ class SettingsRepositoryImpl @Inject constructor(
         return safeApiCall { api.updateMemberSettings(accessToken, request) }
     }
 
-    override suspend fun updateSettings(settings: UserSettingsEntity) {
-        dao.insertSettings(settings) // Room에 덮어쓰기
+    override suspend fun updateSettings(accessToken: String, settings: UserSettingsEntity) {
+        // 1. 로컬 DB에 저장 (UI 즉시 반영) - 동기화 상태 false로 시작
+        dao.insertSettings(settings.copy(isSynced = false))
+
+        try {
+            val request = settings.toUpdateRequest()
+
+            // 2. 서버 API 호출 (Bearer 접두어는 필요시 추가)
+            val token = if (accessToken.startsWith("Bearer ")) accessToken else "Bearer $accessToken"
+            val response = api.updateMemberSettings(token, request)
+
+            if (response.isSuccess) {
+                // 서버 업데이트 성공 시 동기화 상태 true로 변경
+                dao.updateSyncStatus(settings.id, true)
+                Log.d("PACE_SYNC", "서버 동기화 성공")
+            } else {
+                Log.e("PACE_SYNC", "서버 응답 실패: ${response.message}")
+                scheduleSync() // 💡 응답 실패 시 워커 예약
+            }
+        } catch (e: Exception) {
+            Log.e("PACE_SYNC", "네트워크 오류 발생", e)
+            scheduleSync() // 💡 네트워크 오류 시 워커 예약
+        }
+    }
+
+    override suspend fun updateSettingsLocally(settings: UserSettingsEntity) {
+        try {
+            dao.insertSettings(settings)
+            Log.d("PACE_LOCAL", "로컬 DB 업데이트 성공 (서버 동기화 제외)")
+        } catch (e: Exception) {
+            Log.e("PACE_LOCAL", "로컬 DB 업데이트 실패", e)
+        }
     }
 
     override fun getUserSettings(): Flow<UserSettingsEntity?> {
-        return dao.getUserSettings() // 💡 Dao에 정의된 Flow 반환 메서드 호출
+        return dao.getUserSettings()
     }
 
+    private fun scheduleSync() {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val syncRequest = OneTimeWorkRequestBuilder<SyncSettingsWorker>()
+            .setConstraints(constraints)
+            .setBackoffCriteria(
+                BackoffPolicy.EXPONENTIAL,
+                WorkRequest.MIN_BACKOFF_MILLIS,
+                TimeUnit.MILLISECONDS
+            )
+            .build()
+
+        // 💡 이제 생성자에서 주입받은 context를 사용할 수 있습니다.
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            "SettingsSyncWork",
+            ExistingWorkPolicy.REPLACE,
+            syncRequest
+        )
+    }
 }

--- a/app/src/main/java/com/example/pace/data/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/pace/data/viewmodel/SettingsViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.pace.data.datasource.AuthDataStore
 import com.example.pace.data.db.UserSettingsDao
 import com.example.pace.data.model.UserSettingsEntity
-import com.example.pace.data.model.request.AlarmSetting
+import com.example.pace.data.model.request.AlarmSettingRequest
 import com.example.pace.data.model.request.UpdateSettingsRequest
 import com.example.pace.data.repository.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,13 +17,11 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val dao: UserSettingsDao,
-    private val repository: SettingsRepository // 👈 1. 여기에 추가!
+    private val repository: SettingsRepository,
+    private val authDataStore: AuthDataStore // 👈 1. 토큰을 가져오기 위해 주입 추가
 ) : ViewModel() {
-    // 로컬 고정 ID
     private val LOCAL_USER_ID = 1L
 
-    // 1. UI용: Room에서 데이터를 실시간 관찰 (StateFlow)
-    // DB의 값이 바뀌면 UI가 자동으로 업데이트됩니다.
     val userSettings: StateFlow<UserSettingsEntity?> = dao.getSettingsFlow(LOCAL_USER_ID)
         .stateIn(
             scope = viewModelScope,
@@ -31,86 +29,93 @@ class SettingsViewModel @Inject constructor(
             initialValue = null
         )
 
-    // 2. 여유 시간 업데이트 (Room DB에만 저장)
-    fun updateEarlyArrival(minutes: Int) {
+    /**
+     * [공통 로직] 모든 설정 변경은 이 함수를 거치도록 통합하면 코드가 깔끔해집니다.
+     */
+    private fun saveAndSync(updatedEntity: UserSettingsEntity) {
         viewModelScope.launch {
-            dao.updateEarlyArrivalTime(LOCAL_USER_ID, minutes)
-            Log.d("SETTINGS_DEBUG", "로컬 DB 여유시간 변경: $minutes 분")
+            val token = authDataStore.getAccessToken() ?: ""
+            // Repository 내부에서 로컬 DB 저장 + 서버 PATCH를 동시에 수행함
+            repository.updateSettings(token, updatedEntity)
+        }
+    }
+
+    // 2. 여유 시간 업데이트 (서버와 동기화가 필요하다면 saveAndSync 사용)
+    fun updateEarlyArrival(minutes: Int) {
+        userSettings.value?.let {
+            saveAndSync(it.copy(earlyArrivalTime = minutes))
         }
     }
 
     // 3. 리마인더 알림 스위치 업데이트
     fun updateReminderStatus(isActive: Boolean) {
-        viewModelScope.launch {
-            // Dao에 updateReminderStatus 함수가 있다면 사용하세요.
-            // 없다면 전체 Entity를 가져와서 copy 후 update 해야 합니다.
-            val current = dao.getSettings(LOCAL_USER_ID)
-            current?.let {
-                dao.insertSettings(it.copy(isReminderActive = isActive))
-            }
+        userSettings.value?.let {
+            saveAndSync(it.copy(isReminderActive = isActive))
         }
     }
 
+    // 4. 기본 캘린더 변경
     fun updateDefaultCalendar(calendarId: Long) {
-        viewModelScope.launch {
-            val currentSettings = userSettings.first()
-            currentSettings?.let {
-                val updated = it.copy(calendarId = calendarId, isSynced = false)
-                // 👈 2. 이제 repository 참조가 가능해집니다.
-                repository.updateSettings(updated)
-            }
+        userSettings.value?.let {
+            saveAndSync(it.copy(calendarId = calendarId))
         }
     }
+
+    // 5. 동기화할 캘린더 목록 변경
+    // SettingsViewModel.kt
 
     fun toggleCalendarSync(calendarId: Long, isChecked: Boolean) {
         viewModelScope.launch {
+            // 1. 현재 로컬 설정 가져오기
             val currentSettings = userSettings.value ?: return@launch
             val currentList = currentSettings.syncedCalendarIds.toMutableList()
 
+            // 2. 체크 상태에 따라 리스트 수정
             if (isChecked) {
                 if (!currentList.contains(calendarId)) currentList.add(calendarId)
             } else {
                 currentList.remove(calendarId)
             }
 
-            val updated = currentSettings.copy(syncedCalendarIds = currentList, isSynced = false)
-            repository.updateSettings(updated)
+            // 3. 💡 saveAndSync 대신 repository.updateSettingsLocally 사용!
+            // 이렇게 하면 서버 API를 호출하지 않고 로컬 DB만 업데이트합니다.
+            val updatedSettings = currentSettings.copy(
+                syncedCalendarIds = currentList,
+                lastUpdated = System.currentTimeMillis()
+            )
+
+            repository.updateSettingsLocally(updatedSettings)
+
+            Log.d("LOCAL_DB", "캘린더 선택 상태 변경 (로컬): $calendarId -> $isChecked")
         }
     }
 
+    // 6. 알람 시간 업데이트
     fun updateScheduleAlarms(alarms: List<Int>) {
-        viewModelScope.launch {
-            // 1. 현재 StateFlow에 담긴 최신 설정값을 가져옵니다.
-            val currentSettings = userSettings.value
-
-            currentSettings?.let { settings ->
-                // 2. 알람 리스트만 변경한 복사본(copy)을 만듭니다.
-                // take(5)를 통해 DB 저장 직전에도 한 번 더 개수를 방어합니다.
-                val updated = settings.copy(
-                    scheduleAlarms = alarms.take(5),
-                    isSynced = false // 서버와 동기화가 필요하다면 false로 설정
-                )
-
-                // 3. Repository를 통해 로컬 DB 업데이트 및 서버 전송 로직 실행
-                repository.updateSettings(updated)
-
-                Log.d("SETTINGS_DEBUG", "일정 알림 업데이트 성공: ${updated.scheduleAlarms}")
-            }
+        userSettings.value?.let {
+            saveAndSync(it.copy(scheduleAlarms = alarms.take(5)))
         }
     }
 
     fun updateDepartureAlarms(alarms: List<Int>) {
-        viewModelScope.launch {
-            val currentSettings = userSettings.value
-            currentSettings?.let { settings ->
-                val updated = settings.copy(
-                    departureAlarms = alarms.take(5), // 여기서도 5개 제한
-                    isSynced = false
-                )
-                repository.updateSettings(updated)
-                Log.d("SETTINGS_DEBUG", "출발 알림 업데이트 완료: ${updated.departureAlarms}")
-            }
+        userSettings.value?.let {
+            saveAndSync(it.copy(departureAlarms = alarms.take(5)))
         }
     }
+    fun updateSelectedCalendars(selectedIds: List<Long>) {
+        viewModelScope.launch {
+            // 💡 _userSettings가 아니라 userSettings입니다 (오타 수정)
+            val currentSettings = userSettings.value ?: return@launch
 
+            val updatedSettings = currentSettings.copy(
+                syncedCalendarIds = selectedIds,
+                lastUpdated = System.currentTimeMillis()
+            )
+
+            // 서버 통신 없이 DB만 업데이트
+            repository.updateSettingsLocally(updatedSettings)
+
+            Log.d("LOCAL_DB", "선택된 캘린더 ID들 로컬 저장 완료: $selectedIds")
+        }
+    }
 }

--- a/app/src/main/java/com/example/pace/data/worker/SyncSettingsWorker.kt
+++ b/app/src/main/java/com/example/pace/data/worker/SyncSettingsWorker.kt
@@ -7,8 +7,9 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.example.pace.data.datasource.AuthDataStore
 import com.example.pace.data.db.UserSettingsDao
-import com.example.pace.data.model.request.AlarmSetting
+import com.example.pace.data.model.request.AlarmSettingRequest
 import com.example.pace.data.model.request.UpdateSettingsRequest
+import com.example.pace.data.model.toUpdateRequest
 import com.example.pace.data.repository.repository.SettingsRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -22,54 +23,36 @@ class SyncSettingsWorker @AssistedInject constructor(
     private val authDataStore: AuthDataStore
 ) : CoroutineWorker(context, workerParams) {
 
-    // 로컬 DB에서 사용하는 고정 ID
     private val LOCAL_USER_ID = 1L
 
     override suspend fun doWork(): Result {
-        // 1. 고정 ID(1L)에 해당하는 설정 데이터 가져오기 (동기화 여부와 상관없이 최신본)
+        // 1. 로컬 DB에서 최신 설정 데이터 가져오기
         val settings = dao.getSettings(LOCAL_USER_ID) ?: return Result.success()
 
-        // 2. Request 조립
-        val alarmSettings = mutableListOf<AlarmSetting>()
-        if (settings.departureAlarms.isNotEmpty()) {
-            alarmSettings.add(AlarmSetting(type = "DEPARTURE", minutes = settings.departureAlarms))
-        }
-        if (settings.scheduleAlarms.isNotEmpty()) {
-            alarmSettings.add(AlarmSetting(type = "SCHEDULE", minutes = settings.scheduleAlarms))
-        }
-
-        val request = UpdateSettingsRequest(
-            earlyArrivalTime = settings.earlyArrivalTime,
-            isNotiEnabled = true,
-            isLocEnabled = true,
-            isReminderActive = settings.isReminderActive,
-            calendarType = "GOOGLE",
-            reminderTimes = emptyList(),
-            scheduleReminderTimes = settings.scheduleAlarms,
-            departureReminderTimes = settings.departureAlarms,
-            alarms = alarmSettings
-        )
+        // 2. 이미 만들어둔 확장 함수를 사용하여 Request 조립 (필요 없는 필드 자동 정리)
+        val request = settings.toUpdateRequest()
 
         // 3. 토큰 준비
         val token = authDataStore.getAccessToken() ?: ""
+        // 주의: repository.updateMemberSettings 내부에서 "Bearer "를 붙여주는지 확인하세요.
+        // 만약 중복으로 붙지 않게 하려면 아래와 같이 처리합니다.
         val fullToken = if (token.startsWith("Bearer ")) token else "Bearer $token"
 
         return try {
-            // 4. PATCH 요청 전송 (💡 memberId 파라미터 삭제)
+            // 4. 서버 전송
             val response = repository.updateMemberSettings(
                 accessToken = fullToken,
                 request = request
             )
 
             if (response.isSuccess) {
-                // 5. 로컬 DB 동기화 상태만 업데이트 (ID 교체 로직 삭제)
+                // 5. 성공 시 로컬 DB 동기화 상태 업데이트
                 dao.updateSyncStatus(LOCAL_USER_ID, true)
-
                 Log.d("PACE_SYNC", "✅ 백그라운드 설정 동기화 완료")
                 Result.success()
             } else {
                 Log.e("PACE_SYNC", "❌ 동기화 실패: ${response.message}")
-                Result.retry()
+                Result.retry() // 네트워크 문제 등일 경우 다시 시도
             }
         } catch (e: Exception) {
             Log.e("PACE_SYNC", "❌ 에러 발생: ${e.message}")

--- a/app/src/main/java/com/example/pace/module/RepositoryModule.kt
+++ b/app/src/main/java/com/example/pace/module/RepositoryModule.kt
@@ -23,12 +23,14 @@ object RepositoryModule {
     @Provides
     fun providesSettingsRepository(
         settingsService: SettingsService,
-        userSettingsDao: UserSettingsDao // 👈 DAO 주입 추가
+        userSettingsDao: UserSettingsDao, // 👈 DAO 주입 추가
+        @ApplicationContext context: Context
     ) : SettingsRepository {
         // 구현체 생성자에 DAO와 Service를 순서대로 전달
         return SettingsRepositoryImpl(
             dao = userSettingsDao,
-            api = settingsService
+            api = settingsService,
+            context = context
         )
     }
 

--- a/app/src/main/java/com/example/pace/ui/add_schedule/CalendarSelectAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/CalendarSelectAdapter.kt
@@ -1,67 +1,79 @@
 package com.example.pace.ui.add_schedule
 
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.example.pace.R // [중요] android.R 대신 프로젝트의 R을 임포트하세요
+import com.example.pace.R
 import com.example.pace.data.model.CalendarAccount
 
 class CalendarSelectAdapter(
-    private val items: List<CalendarAccount>,
-    private val initialId: Long?,
-    private val onItemClick: (CalendarAccount) -> Unit // 💡 콜백 추가
+    private var items: List<CalendarAccount>,
+    private var selectedId: Long?,
+    private val onItemClick: (CalendarAccount) -> Unit
 ) : RecyclerView.Adapter<CalendarSelectAdapter.ViewHolder>() {
 
-    private var selectedPosition = items.indexOfFirst { it.id.toLong() == initialId }.let {
-        if (it == -1) 0 else it
+    // 💡 List 업데이트를 위한 함수 (필요 시 호출)
+    fun updateData(newList: List<CalendarAccount>, currentId: Long?) {
+        this.items = newList
+        this.selectedId = currentId
+        notifyDataSetChanged()
     }
-
-    // 현재 선택된 아이템을 반환하는 함수 추가
-    fun getSelectedItem(): CalendarAccount? {
-        return if (items.isNotEmpty()) items[selectedPosition] else null
-    }
-
 
     inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val tvName: TextView = view.findViewById(R.id.tv_calendar_item_name)
         val tvAccount: TextView = view.findViewById(R.id.tv_calendar_item_account)
         val rbSelect: RadioButton = view.findViewById(R.id.rb_calendar_select)
 
-        fun bind(item: CalendarAccount, position: Int) {
+        fun bind(item: CalendarAccount, isSelected: Boolean) {
             tvName.text = item.displayName
             tvAccount.text = item.accountName
 
-            // 💡 중요: 라디오버튼의 상태를 현재 position과 비교해서 결정
-            rbSelect.isChecked = (position == selectedPosition)
+            // 1. 라디오 버튼 체크 상태 설정
+            rbSelect.isChecked = isSelected
 
+            // 2. 디자인 요구사항: 체크 상태에 따른 색상 설정 (#98BD0B)
+            val colorStateList = ColorStateList(
+                arrayOf(
+                    intArrayOf(android.R.attr.state_checked),  // 체크된 상태
+                    intArrayOf(-android.R.attr.state_checked) // 체크되지 않은 상태
+                ),
+                intArrayOf(
+                    Color.parseColor("#98BD0B"), // 체크 시 색상 (primary_500)
+                    Color.parseColor("#D1D1D1")  // 미체크 시 테두리 색상
+                )
+            )
+            rbSelect.buttonTintList = colorStateList
+
+            // 3. 아이템 전체 클릭 리스너
             itemView.setOnClickListener {
-                val currentPos = adapterPosition
-                if (currentPos != RecyclerView.NO_POSITION && selectedPosition != currentPos) {
-                    val oldPos = selectedPosition
-                    selectedPosition = currentPos
-                    notifyItemChanged(oldPos)
-                    notifyItemChanged(selectedPosition)
-
-                    onItemClick(item)
-
+                val itemId = item.id.toLongOrNull() ?: -1L
+                if (selectedId != itemId) {
+                    selectedId = itemId // 선택된 ID 업데이트
+                    notifyDataSetChanged() // 전체 갱신 (라디오 버튼 상태 반영)
+                    onItemClick(item)      // 콜백 실행
                 }
             }
 
-            // 라디오 버튼 자체를 눌러도 클릭 이벤트가 작동하도록 설정
-            rbSelect.setOnClickListener { itemView.performClick() }
+            // 라디오 버튼 터치 시에도 부모 클릭 이벤트가 작동하도록 설정
+            rbSelect.isClickable = false
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        // XML 파일명이 item_calendar_select인지 확인하세요
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_calendar_select, parent, false)
         return ViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(items[position], position)
+        val item = items[position]
+        val itemId = item.id.toLongOrNull() ?: -1L
+        holder.bind(item, itemId == selectedId)
     }
 
     override fun getItemCount() = items.size

--- a/app/src/main/java/com/example/pace/ui/add_schedule/GerneralScheduleFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/GerneralScheduleFragment.kt
@@ -229,25 +229,17 @@ class GeneralScheduleFragment : Fragment() {
 
         setupKeyboardVisibilityListener()
 
-        setFragmentResultListener("repeatKey") { _, bundle ->
-            val resultText = bundle.getString("selectedRepeat")
-            binding.tvRepeatStatus.text = resultText
-
-            // 안전한 추출 방법
-            currentRepeatInfo = try {
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-                    bundle.getSerializable("repeatInfo", RepeatInfo::class.java)
-                } else {
-                    @Suppress("DEPRECATION")
-                    bundle.getSerializable("repeatInfo") as? RepeatInfo
-                }
-            } catch (e: Exception) {
-                null
-            }
-        }
-
+        // 반복 버튼 눌렀을 때 선택된 시작 날짜 보내주기
         binding.btnRepeat.setOnClickListener {
-            val repeatFragment = ScheduleRepeatFragment()
+            val dateToSend = startDate?.toString() ?: LocalDate.now().toString()
+
+            val repeatFragment = ScheduleRepeatFragment().apply {
+                arguments = Bundle().apply {
+                    putString("startDate", dateToSend)
+                    // 기존에 설정된 리핏 인포가 있다면 함께 전달
+                    putSerializable("existingRepeatInfo", currentRepeatInfo)
+                }
+            }
 
             requireActivity().supportFragmentManager.beginTransaction()
                 .setCustomAnimations(
@@ -529,6 +521,21 @@ class GeneralScheduleFragment : Fragment() {
                 }
             }
         }
+
+        setFragmentResultListener("repeatKey") { _, bundle ->
+            val resultText = bundle.getString("selectedRepeat")
+            binding.tvRepeatStatus.text = resultText
+            binding.tvRepeatStatus.setTextColor(ContextCompat.getColor(requireContext(), R.color.black))
+
+            // RepeatInfo 객체가 넘어올 경우 저장
+            currentRepeatInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                bundle.getSerializable("repeatInfo", RepeatInfo::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                bundle.getSerializable("repeatInfo") as? RepeatInfo
+            }
+        }
+
     }
 
 

--- a/app/src/main/java/com/example/pace/ui/add_schedule/ScheduleRepeatFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/ScheduleRepeatFragment.kt
@@ -1,6 +1,8 @@
 package com.example.pace.ui.add_schedule
 
 import android.content.Context
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -9,10 +11,22 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.*
+import androidx.activity.OnBackPressedCallback
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.example.pace.R
+import com.example.pace.data.model.request.RepeatInfo
 import com.example.pace.databinding.FragmentScheduleRepeatBinding
+import com.example.pace.databinding.ItemCalendarDayAddscheduleBinding
+import com.kizitonwose.calendar.core.CalendarDay
+import com.kizitonwose.calendar.core.DayPosition
+import com.kizitonwose.calendar.core.daysOfWeek
+import com.kizitonwose.calendar.view.MonthDayBinder
+import com.kizitonwose.calendar.view.ViewContainer
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 import java.util.*
 
 class ScheduleRepeatFragment : Fragment() {
@@ -20,14 +34,38 @@ class ScheduleRepeatFragment : Fragment() {
     private var _binding: FragmentScheduleRepeatBinding? = null
     private val binding get() = _binding!!
 
-    // 현재 인플레이트되어 붙어있는 상세 레이아웃 (주간/월간 등)
     private var detailView: View? = null
+    private var selectedEndDate: LocalDate? = LocalDate.now().plusWeeks(1) // 기본값 1주일 뒤
 
-    // 공통 TextWatcher
+    // 날짜 포맷터 추가
+    private val monthFormatter = DateTimeFormatter.ofPattern("yyyy년 M월")
+    // 기존 dateFormatter를 요일이 포함된 형식으로 수정
+    private val dateFormatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일 (E)", Locale.KOREAN)
+
+    private lateinit var baseDate: LocalDate
+    private var existingInfo: RepeatInfo? = null
+
+
     private val descriptionWatcher = object : TextWatcher {
         override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
         override fun afterTextChanged(s: Editable?) { updateFullDescription() }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            val dateStr = it.getString("startDate")
+            baseDate = if (dateStr != null) LocalDate.parse(dateStr) else LocalDate.now()
+
+            // 기존 설정 정보 가져오기
+            existingInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                it.getSerializable("existingRepeatInfo", RepeatInfo::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                it.getSerializable("existingRepeatInfo") as? RepeatInfo
+            }
+        }
     }
 
     override fun onCreateView(
@@ -42,41 +80,94 @@ class ScheduleRepeatFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupMainListeners()
-        updateFullDescription()
+        setupCalendar()
+        setupLegend()
+        if (existingInfo != null) {
+            restorePreviousSettings(existingInfo!!)
+        } else {
+            updateFullDescription()
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                sendResultAndBack()
+            }
+        })
     }
 
     private fun setupMainListeners() {
         binding.repeatToolbar.setNavigationOnClickListener { sendResultAndBack() }
 
-        // 메인 반복 옵션 (안함, 일간, 주간, 월간, 연간)
         binding.rgRepeatOptions.setOnCheckedChangeListener { _, checkedId ->
             handleLayoutSwitch(checkedId)
             updateFullDescription()
         }
 
-        val endRadioButtons = listOf(binding.rbEndNever, binding.rbEndCount, binding.rbEndDate)
+        binding.rgEndOptions.setOnCheckedChangeListener { _, checkedId ->
+            // 어떤 옵션을 누르든 일단 키보드부터 내림
+            hideKeyboard()
 
+            // 포커스를 라디오 그룹으로 강제 이동시켜 EditText에서 포커스를 뺏어옴
+            binding.rgEndOptions.requestFocus()
+
+            handleEndLayoutVisibility()
+            updateFullDescription()
+
+            if (checkedId == R.id.rb_end_count) {
+                // '횟수 지정'일 때만 다시 키보드 올림
+                binding.etEndCount.postDelayed({ // 레이아웃 안정화 후 키보드 팝업
+                    binding.etEndCount.requestFocus()
+                    val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                    imm.showSoftInput(binding.etEndCount, InputMethodManager.SHOW_IMPLICIT)
+                }, 100)
+            }
+        }
+
+        binding.rbEndNever.setOnClickListener {
+            // 1. 강제 포커스 해제 (EditText에서 포커스를 완전히 뺏어옴)
+            binding.etEndCount.clearFocus()
+
+            // 2. 키보드 즉시 숨김
+            val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(view?.windowToken, 0)
+
+            // 3. 라디오 버튼 체크 강제 수행 (간혹 이벤트가 씹히는 것 방지)
+            binding.rbEndNever.isChecked = true
+            handleEndLayoutVisibility()
+            updateFullDescription()
+        }
+
+        val endRadioButtons = listOf(binding.rbEndNever, binding.rbEndCount, binding.rbEndDate)
         endRadioButtons.forEach { rb ->
             rb.setOnClickListener { clickedView ->
-                // 1. 모든 종료 관련 라디오 버튼의 체크를 해제한 뒤, 클릭된 것만 체크
                 endRadioButtons.forEach { it.isChecked = (it == clickedView) }
-
-                // 2. 횟수 입력창(layout_count_input) 등의 가시성 조절
                 handleEndLayoutVisibility()
-
-                // 3. 상단 요약 텍스트 업데이트
                 updateFullDescription()
 
-                // 4. 횟수 지정 클릭 시 키보드 바로 띄우기 (편의 기능)
                 if (clickedView == binding.rbEndCount) {
                     binding.etEndCount.requestFocus()
-                    val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
-                    imm.showSoftInput(binding.etEndCount, android.view.inputmethod.InputMethodManager.SHOW_IMPLICIT)
+                    val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                    imm.showSoftInput(binding.etEndCount, InputMethodManager.SHOW_IMPLICIT)
                 }
             }
         }
 
         binding.etEndCount.addTextChangedListener(descriptionWatcher)
+
+        // 캘린더 월 이동 리스너
+        binding.btnPrevMonth.setOnClickListener {
+            binding.calendarPicker.findFirstVisibleMonth()?.let {
+                // scrollToMonth 대신 smoothScrollToMonth 사용
+                binding.calendarPicker.smoothScrollToMonth(it.yearMonth.minusMonths(1))
+            }
+        }
+
+        binding.btnNextMonth.setOnClickListener {
+            binding.calendarPicker.findFirstVisibleMonth()?.let {
+                // scrollToMonth 대신 smoothScrollToMonth 사용
+                binding.calendarPicker.smoothScrollToMonth(it.yearMonth.plusMonths(1))
+            }
+        }
     }
 
     private fun handleLayoutSwitch(checkedId: Int) {
@@ -94,12 +185,12 @@ class ScheduleRepeatFragment : Fragment() {
         container.visibility = View.VISIBLE
         binding.layoutCommonRepeatEnd.visibility = View.VISIBLE
 
-        // 레이아웃 인플레이트
         val layoutId = when (checkedId) {
+            R.id.rb_daily -> R.layout.layout_repeat_daily
             R.id.rb_week -> R.layout.layout_repeat_weekly
             R.id.rb_month -> R.layout.layout_repeat_monthly
             R.id.rb_year -> R.layout.layout_repeat_yearly
-            else -> null // 일간은 별도 레이아웃 없이 간격만 처리 가능
+            else -> null
         }
 
         layoutId?.let {
@@ -112,67 +203,222 @@ class ScheduleRepeatFragment : Fragment() {
     private fun setupDetailListeners(checkedId: Int) {
         val v = detailView ?: return
         when (checkedId) {
+            R.id.rb_daily -> {
+                v.findViewById<EditText>(R.id.et_daily_interval)?.addTextChangedListener(descriptionWatcher)
+            }
             R.id.rb_week -> {
+                // 주간 전용 반복주기 보여지게하기
+                v.findViewById<View>(R.id.layout_day_of_week)?.visibility = View.VISIBLE
+
                 v.findViewById<EditText>(R.id.et_week_interval)?.addTextChangedListener(descriptionWatcher)
                 val dayIds = listOf(R.id.cb_sun, R.id.cb_mon, R.id.cb_tue, R.id.cb_wed, R.id.cb_thu, R.id.cb_fri, R.id.cb_sat)
                 dayIds.forEach { id ->
                     v.findViewById<CheckBox>(id)?.setOnCheckedChangeListener { _, _ -> updateFullDescription() }
                 }
+
+                // 오늘날짜 자동 추가
+                 val today = Calendar.getInstance().get(Calendar.DAY_OF_WEEK) - 1
+                 v.findViewById<CheckBox>(dayIds[today])?.isChecked = true
             }
             R.id.rb_month -> {
-                // 1. detailView가 null인지 먼저 확인 (let 사용 권장)
-                val v = detailView ?: return
-
                 val rgMonthly = v.findViewById<RadioGroup>(R.id.rg_monthly_detail)
                 val gridDates = v.findViewById<GridLayout>(R.id.grid_monthly_dates)
                 val rbOrdinal = v.findViewById<RadioButton>(R.id.rb_monthly_ordinal_day)
                 val rbFixed = v.findViewById<RadioButton>(R.id.rb_monthly_day_fixed)
 
-
-                // 2. 텍스트 설정
-                val dayOfMonth = java.util.Calendar.getInstance().get(java.util.Calendar.DAY_OF_MONTH)
+                val dayOfMonth = Calendar.getInstance().get(Calendar.DAY_OF_MONTH)
                 rbFixed?.text = "${dayOfMonth}일 마다 반복"
                 rbOrdinal?.text = "${getOrdinalDayOfWeekText()} 마다 반복"
 
-                // 3. 그리드 초기화
                 gridDates?.let { setupDateGrid(it) }
-
-                // 4. 리스너 등록
                 rgMonthly?.setOnCheckedChangeListener { _, checkedId ->
-                    // ID 오타 수정: rb_monthly_specific_date
                     gridDates?.visibility = if (checkedId == R.id.rb_monthly_specific_date) View.VISIBLE else View.GONE
                     updateFullDescription()
                 }
+                v.findViewById<EditText>(R.id.et_month_interval)?.addTextChangedListener(descriptionWatcher)
             }
             R.id.rb_year -> {
-                val v = detailView ?: return // return@let 대신 return 사용
-
                 val rgYearly = v.findViewById<RadioGroup>(R.id.rg_yearly_detail)
                 val gridMonths = v.findViewById<GridLayout>(R.id.grid_yearly_months)
-                val rbSpecific = v.findViewById<RadioButton>(R.id.rb_yearly_specific_date) // XML ID와 일치
-
-                // 1. 1월~12월 그리드 생성 (이 함수가 반드시 호출되어야 달이 생깁니다)
                 gridMonths?.let { setupMonthGrid(it) }
-
-                // 2. 라디오 버튼 클릭 리스너 설정
                 rgYearly?.setOnCheckedChangeListener { _, checkedId ->
-                    // 사용자가 '반복 날짜 선택'을 눌렀을 때만 그리드를 보여줌
                     gridMonths?.visibility = if (checkedId == R.id.rb_yearly_specific_date) View.VISIBLE else View.GONE
                     updateFullDescription()
                 }
-
-                // 간격(n년마다) 입력창 리스너
                 v.findViewById<EditText>(R.id.et_year_interval)?.addTextChangedListener(descriptionWatcher)
             }
         }
     }
 
-    // 1~31일 그리드 생성 함수
+    private fun updateFullDescription() {
+        val typeId = binding.rgRepeatOptions.checkedRadioButtonId
+        if (typeId == R.id.rb_none) {
+            binding.tvRepeatDescription.text = "일정 반복을 진행하지 않습니다."
+            return
+        }
+
+        val interval = when (typeId) {
+            R.id.rb_daily -> detailView?.findViewById<EditText>(R.id.et_daily_interval)?.text.toString()
+            R.id.rb_week -> detailView?.findViewById<EditText>(R.id.et_week_interval)?.text.toString()
+            R.id.rb_month -> detailView?.findViewById<EditText>(R.id.et_month_interval)?.text.toString()
+            R.id.rb_year -> detailView?.findViewById<EditText>(R.id.et_year_interval)?.text.toString()
+            else -> "1"
+        }.ifEmpty { "1" }
+
+        var detailInfo = ""
+        when (typeId) {
+            R.id.rb_week -> {
+                val selectedDays = mutableListOf<String>()
+                val dayNames = listOf("일", "월", "화", "수", "목", "금", "토")
+                val dayIds = listOf(R.id.cb_sun, R.id.cb_mon, R.id.cb_tue, R.id.cb_wed, R.id.cb_thu, R.id.cb_fri, R.id.cb_sat)
+                dayIds.forEachIndexed { i, id ->
+                    if (detailView?.findViewById<CheckBox>(id)?.isChecked == true) selectedDays.add(dayNames[i])
+                }
+                if (selectedDays.isNotEmpty()) detailInfo = "${selectedDays.joinToString(", ")}요일"
+            }
+            R.id.rb_month -> {
+                val v = detailView ?: return
+                if (v.findViewById<RadioButton>(R.id.rb_monthly_specific_date)?.isChecked == true) {
+                    val selectedDates = mutableListOf<Int>()
+                    val grid = v.findViewById<GridLayout>(R.id.grid_monthly_dates)
+                    for (i in 0 until (grid?.childCount ?: 0)) {
+                        val cb = grid?.getChildAt(i) as? CheckBox
+                        if (cb?.isChecked == true) selectedDates.add(cb.text.toString().toInt())
+                    }
+                    if (selectedDates.isNotEmpty()) detailInfo = "${selectedDates.sorted().joinToString(", ")}일"
+                }
+            }
+            R.id.rb_year -> {
+                val v = detailView ?: return
+                if (v.findViewById<RadioButton>(R.id.rb_yearly_specific_date)?.isChecked == true) {
+                    val selectedMonths = mutableListOf<String>()
+                    val grid = v.findViewById<GridLayout>(R.id.grid_yearly_months)
+                    for (i in 0 until (grid?.childCount ?: 0)) {
+                        val cb = grid?.getChildAt(i) as? CheckBox
+                        if (cb?.isChecked == true) selectedMonths.add(cb.text.toString())
+                    }
+                    if (selectedMonths.isNotEmpty()) detailInfo = "${selectedMonths.joinToString(", ")} 반복"
+                }
+            }
+        }
+
+        val unit = when(typeId) {
+            R.id.rb_daily -> "일"
+            R.id.rb_week -> "주"
+            R.id.rb_month -> "개월"
+            R.id.rb_year -> "년"
+            else -> ""
+        }
+        val intervalText = if (interval == "1") "매$unit" else "${interval}${unit}마다"
+
+        // 종료 부분에 선택된 날짜 포맷 반영
+        val endText = when {
+            binding.rbEndNever.isChecked -> "반복됩니다"
+            binding.rbEndCount.isChecked -> "${binding.etEndCount.text.toString().ifEmpty { "1" }}회 반복됩니다"
+            binding.rbEndDate.isChecked -> "${selectedEndDate?.format(dateFormatter)}까지 반복됩니다"
+            else -> "반복됩니다"
+        }
+
+        binding.tvRepeatDescription.text = "$intervalText $detailInfo $endText".replace("\\s+".toRegex(), " ").trim()
+    }
+
+    private fun handleEndLayoutVisibility() {
+
+        val checkedId = binding.rgEndOptions.checkedRadioButtonId
+        binding.layoutCountInput.isVisible = (checkedId == R.id.rb_end_count)
+        binding.calendarContainer.isVisible = (checkedId == R.id.rb_end_date)
+
+        if (checkedId != R.id.rb_end_count) {
+            hideKeyboard() // 횟수 지정이 아니면 키보드 닫기
+        }
+
+        // 1. 횟수 지정 레이아웃 제어
+        if (binding.rbEndCount.isChecked) {
+            binding.rbEndCount.text = ""
+            binding.layoutCountInput.visibility = View.VISIBLE
+        } else {
+            binding.rbEndCount.text = "횟수 지정"
+            binding.layoutCountInput.visibility = View.GONE
+        }
+
+        // 2. 종료 날짜 텍스트 및 캘린더 컨테이너 제어
+        if (binding.rbEndDate.isChecked) {
+            // [종료 날짜 선택됨] 선택된 날짜를 "0000년 00월 00일 (목)까지" 형식으로 표시
+            val formattedDate = selectedEndDate?.format(dateFormatter) ?: ""
+            binding.rbEndDate.text = "${formattedDate} 까지"
+            binding.calendarContainer.visibility = View.VISIBLE
+        } else {
+            // [다른 옵션 선택됨] 다시 "종료 날짜"로 텍스트 복구
+            binding.rbEndDate.text = "종료 날짜"
+            binding.calendarContainer.visibility = View.GONE
+        }
+    }
+
+    private fun setupCalendar() {
+        val currentMonth = java.time.YearMonth.now()
+        val startMonth = currentMonth.minusMonths(12) // 1년 전
+        val endMonth = currentMonth.plusMonths(12)   // 1년 후 (총 2년)
+        val firstDayOfWeek = java.time.DayOfWeek.SUNDAY
+
+        binding.calendarPicker.setup(startMonth, endMonth, firstDayOfWeek)
+        binding.calendarPicker.scrollToMonth(currentMonth)
+
+        class DayViewContainer(view: View) : ViewContainer(view) {
+            val textView = ItemCalendarDayAddscheduleBinding.bind(view).calendarDayText
+            lateinit var day: CalendarDay
+
+            init {
+                view.setOnClickListener {
+                    if (day.position == DayPosition.MonthDate) {
+                        val oldDate = selectedEndDate
+                        selectedEndDate = day.date
+
+                        // 변경된 날짜 알림
+                        binding.calendarPicker.notifyDateChanged(day.date)
+                        oldDate?.let { binding.calendarPicker.notifyDateChanged(it) }
+
+                        // 중요: 라디오 버튼 텍스트와 하단 전체 설명을 모두 갱신
+                        handleEndLayoutVisibility()
+                        updateFullDescription()
+                    }
+                }
+            }
+        }
+
+        binding.calendarPicker.dayBinder = object : MonthDayBinder<DayViewContainer> {
+            override fun create(view: View) = DayViewContainer(view)
+            override fun bind(container: DayViewContainer, data: CalendarDay) {
+                container.day = data
+                container.textView.text = data.date.dayOfMonth.toString()
+
+                if (data.position == DayPosition.MonthDate) {
+                    container.textView.visibility = View.VISIBLE
+
+                    if (data.date == selectedEndDate) {
+                        // [선택된 날짜] 초록색 원 배경 + 하얀색 글씨
+                        container.textView.setBackgroundResource(R.drawable.drawable_circle_green)
+                        container.textView.setTextColor(android.graphics.Color.WHITE)
+                    } else {
+                        // [일반 날짜] 배경 없음 + 검정색 글씨 (또는 기본색)
+                        container.textView.background = null
+                        container.textView.setTextColor(resources.getColor(R.color.black, null))
+                    }
+                } else {
+                    // 이번 달이 아닌 날짜들 숨김
+                    container.textView.visibility = View.INVISIBLE
+                }
+            }
+        }
+
+        binding.calendarPicker.monthScrollListener = { month ->
+            binding.tvCurrentMonth.text = monthFormatter.format(month.yearMonth)
+        }
+    }
+
+    // --- 유틸리티 ---
     private fun setupDateGrid(grid: GridLayout) {
         grid.removeAllViews()
-        // 7열로 확실히 고정
         grid.columnCount = 7
-
         for (i in 1..31) {
             val cb = CheckBox(requireContext()).apply {
                 text = i.toString()
@@ -180,21 +426,11 @@ class ScheduleRepeatFragment : Fragment() {
                 gravity = android.view.Gravity.CENTER
                 setBackgroundResource(R.drawable.bg_month_circle)
                 setTextColor(androidx.core.content.ContextCompat.getColorStateList(context, R.color.selector_month_text))
-
                 textSize = 12f
-                setTypeface(null, android.graphics.Typeface.NORMAL)
-
                 layoutParams = GridLayout.LayoutParams().apply {
-                    // 한 줄에 7개를 넣기 위해 너비를 약간 줄여 38dp~40dp로 고정
                     width = dpToPx(38)
                     height = dpToPx(38)
-
-                    // 마진을 최소화하여 7개가 한 줄에 들어가도록 함
                     setMargins(dpToPx(1), dpToPx(4), dpToPx(1), dpToPx(4))
-
-                    // 가중치를 제거하거나 상위 뷰의 여백에 맞춰 조정
-                    columnSpec = GridLayout.spec(GridLayout.UNDEFINED)
-                    rowSpec = GridLayout.spec(GridLayout.UNDEFINED)
                 }
                 setOnCheckedChangeListener { _, _ -> updateFullDescription() }
             }
@@ -207,15 +443,12 @@ class ScheduleRepeatFragment : Fragment() {
         for (i in 1..12) {
             val cb = CheckBox(requireContext()).apply {
                 text = "${i}월"
-                buttonDrawable = null // 기본 체크박스 제거
+                buttonDrawable = null
                 gravity = android.view.Gravity.CENTER
                 setBackgroundResource(R.drawable.bg_month_circle)
                 setTextColor(androidx.core.content.ContextCompat.getColorStateList(context, R.color.selector_month_text))
                 textSize = 12f
-                setTypeface(null, android.graphics.Typeface.NORMAL)
-
                 layoutParams = GridLayout.LayoutParams().apply {
-                    // 원형 유지를 위해 가로세로를 동일한 px로 고정
                     width = dpToPx(42)
                     height = dpToPx(42)
                     setMargins(dpToPx(2), dpToPx(8), dpToPx(2), dpToPx(8))
@@ -228,153 +461,203 @@ class ScheduleRepeatFragment : Fragment() {
     }
 
     private fun getOrdinalDayOfWeekText(): String {
-        val calendar = java.util.Calendar.getInstance() // 실제로는 일정 시작일을 넣는 것을 권장합니다.
+        val calendar = Calendar.getInstance()
         val dayNames = listOf("일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일")
-
-        val dayOfWeekName = dayNames[calendar.get(java.util.Calendar.DAY_OF_WEEK) - 1]
-        val ordinal = calendar.get(java.util.Calendar.DAY_OF_WEEK_IN_MONTH)
-
+        val dayOfWeekName = dayNames[calendar.get(Calendar.DAY_OF_WEEK) - 1]
+        val ordinal = calendar.get(Calendar.DAY_OF_WEEK_IN_MONTH)
         val ordinalNames = listOf("첫 번째", "두 번째", "세 번째", "네 번째", "다섯 번째")
-        val ordinalText = if (ordinal <= 5) ordinalNames[ordinal - 1] else ""
-
-        return "$ordinalText $dayOfWeekName"
-    }
-
-    fun getOrdinalDayOfWeek(date: Date): String {
-        val calendar = Calendar.getInstance().apply { time = date }
-
-        val dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK) // 요일 (1:일, 2:월 ... 6:금)
-        val ordinal = calendar.get(Calendar.DAY_OF_WEEK_IN_MONTH) // 몇 번째인지 (1~5)
-
-        val dayName = when(dayOfWeek) {
-            Calendar.SUNDAY -> "일요일"
-            Calendar.MONDAY -> "월요일"
-            Calendar.TUESDAY -> "화요일"
-            Calendar.WEDNESDAY -> "수요일"
-            Calendar.THURSDAY -> "목요일"
-            Calendar.FRIDAY -> "금요일"
-            Calendar.SATURDAY -> "토요일"
-            else -> ""
-        }
-
-        val ordinalName = when(ordinal) {
-            1 -> "첫 번째"
-            2 -> "두 번째"
-            3 -> "세 번째"
-            4 -> "네 번째"
-            5 -> "다섯 번째"
-            else -> ""
-        }
-
-        return "$ordinalName $dayName"
-    }
-
-    private fun updateFullDescription() {
-        val typeId = binding.rgRepeatOptions.checkedRadioButtonId
-        if (typeId == R.id.rb_none) {
-            binding.tvRepeatDescription.text = "일정 반복을 진행하지 않습니다."
-            return
-        }
-
-        // 1. 간격(Interval) 추출
-        val interval = when (typeId) {
-            R.id.rb_week -> detailView?.findViewById<EditText>(R.id.et_week_interval)?.text.toString()
-            R.id.rb_month -> detailView?.findViewById<EditText>(R.id.et_month_interval)?.text.toString()
-            R.id.rb_year -> detailView?.findViewById<EditText>(R.id.et_year_interval)?.text.toString()
-            else -> "1" // 일간 등
-        }.ifEmpty { "1" }
-
-        // 2. 상세 정보 (주간 요일 / 월간 날짜)
-        var detailInfo = ""
-        if (typeId == R.id.rb_week) {
-            val selectedDays = mutableListOf<String>()
-            val dayNames = listOf("일", "월", "화", "수", "목", "금", "토")
-            val dayIds = listOf(R.id.cb_sun, R.id.cb_mon, R.id.cb_tue, R.id.cb_wed, R.id.cb_thu, R.id.cb_fri, R.id.cb_sat)
-            dayIds.forEachIndexed { i, id ->
-                if (detailView?.findViewById<CheckBox>(id)?.isChecked == true) selectedDays.add(dayNames[i])
-            }
-            if (selectedDays.isNotEmpty()) detailInfo = "${selectedDays.joinToString(", ")}요일"
-        }
-
-        if (typeId == R.id.rb_month) {
-            val v = detailView ?: return
-            val isSpecificDate = v.findViewById<RadioButton>(R.id.rb_monthly_specific_date)?.isChecked == true
-
-            if (isSpecificDate) {
-                val selectedDates = mutableListOf<Int>()
-                val grid = v.findViewById<GridLayout>(R.id.grid_monthly_dates)
-                for (i in 0 until (grid?.childCount ?: 0)) {
-                    val cb = grid?.getChildAt(i) as? CheckBox
-                    if (cb?.isChecked == true) {
-                        selectedDates.add(cb.text.toString().toInt())
-                    }
-                }
-                if (selectedDates.isNotEmpty()) {
-                    detailInfo = "${selectedDates.sorted().joinToString(", ")}일"
-                }
-            }
-        }
-
-        if (typeId == R.id.rb_year) {
-            val v = detailView ?: return
-            val isSpecificMonth = v.findViewById<RadioButton>(R.id.rb_yearly_specific_date)?.isChecked == true
-
-            if (isSpecificMonth) {
-                val selectedMonths = mutableListOf<String>()
-                val grid = v.findViewById<GridLayout>(R.id.grid_yearly_months)
-                for (i in 0 until (grid?.childCount ?: 0)) {
-                    val cb = grid?.getChildAt(i) as? CheckBox
-                    if (cb?.isChecked == true) selectedMonths.add(cb.text.toString())
-                }
-                if (selectedMonths.isNotEmpty()) detailInfo = "${selectedMonths.joinToString(", ")} 반복"
-            }
-        }
-
-        // 3. 문장 조합
-        val unit = when(typeId) {
-            R.id.rb_daily -> "일"
-            R.id.rb_week -> "주"
-            R.id.rb_month -> "개월"
-            R.id.rb_year -> "년"
-            else -> ""
-        }
-        val intervalText = if (interval == "1") "매$unit" else "${interval}${unit}마다"
-
-        val endText = when {
-            binding.rbEndNever.isChecked -> "반복됩니다"
-            binding.rbEndCount.isChecked -> "${binding.etEndCount.text.toString().ifEmpty { "1" }}회 반복됩니다"
-            binding.rbEndDate.isChecked -> "종료 날짜까지 반복됩니다"
-            else -> "반복됩니다"
-        }
-
-        binding.tvRepeatDescription.text = "$intervalText $detailInfo $endText".replace("  ", " ").trim()
-    }
-
-    private fun handleEndLayoutVisibility() {
-        if (binding.rbEndCount.isChecked) {
-            // 체크되었을 때 '횟수 지정' 글자를 지우고 입력창을 보여줌
-            binding.rbEndCount.text = ""
-            binding.layoutCountInput.visibility = View.VISIBLE
-        } else {
-            // 체크 해제 시 다시 글자를 보여주고 입력창을 숨김
-            binding.rbEndCount.text = "횟수 지정"
-            binding.layoutCountInput.visibility = View.GONE
-        }
+        return "${if (ordinal <= 5) ordinalNames[ordinal - 1] else ""} $dayOfWeekName"
     }
 
     private fun sendResultAndBack() {
-        // 현재 요약된 텍스트를 결과로 전달
-        val finalResult = binding.tvRepeatDescription.text.toString()
-        parentFragmentManager.setFragmentResult("repeatKey", bundleOf("selectedRepeat" to finalResult))
+        val typeId = binding.rgRepeatOptions.checkedRadioButtonId
+
+        // 1. 반복 안 함일 경우
+        if (typeId == R.id.rb_none) {
+            parentFragmentManager.setFragmentResult("repeatKey", bundleOf(
+                "selectedRepeat" to "반복 안함",
+                "repeatInfo" to null
+            ))
+            parentFragmentManager.popBackStack()
+            return
+        }
+
+        // 2. RepeatInfo 객체 생성
+        val repeatType = when (typeId) {
+            R.id.rb_daily -> "DAILY"
+            R.id.rb_week -> "WEEKLY"
+            R.id.rb_month -> "MONTHLY"
+            R.id.rb_year -> "YEARLY"
+            else -> "NONE"
+        }
+
+        // 간격(Interval) 추출
+        val interval = when (typeId) {
+            R.id.rb_daily -> detailView?.findViewById<EditText>(R.id.et_daily_interval)?.text.toString()
+            R.id.rb_week -> detailView?.findViewById<EditText>(R.id.et_week_interval)?.text.toString()
+            R.id.rb_month -> detailView?.findViewById<EditText>(R.id.et_month_interval)?.text.toString()
+            R.id.rb_year -> detailView?.findViewById<EditText>(R.id.et_year_interval)?.text.toString()
+            else -> "1"
+        }.ifEmpty { "1" }.toInt()
+
+        // 요일(daysOfWeek) 추출 (주간 반복일 때만)
+        var daysOfWeekStr: String? = null
+        if (typeId == R.id.rb_week) {
+            val selectedDays = mutableListOf<String>()
+            val codes = listOf("SU", "MO", "TU", "WE", "TH", "FR", "SA")
+            val dayIds = listOf(R.id.cb_sun, R.id.cb_mon, R.id.cb_tue, R.id.cb_wed, R.id.cb_thu, R.id.cb_fri, R.id.cb_sat)
+            dayIds.forEachIndexed { i, id ->
+                if (detailView?.findViewById<CheckBox>(id)?.isChecked == true) {
+                    selectedDays.add(codes[i])
+                }
+            }
+            if (selectedDays.isNotEmpty()) daysOfWeekStr = selectedDays.joinToString(",")
+        }
+
+        // 종료 조건 추출
+        val endType = when {
+            binding.rbEndNever.isChecked -> "NEVER"
+            binding.rbEndCount.isChecked -> "COUNT"
+            binding.rbEndDate.isChecked -> "DATE"
+            else -> "NEVER"
+        }
+        val endCount = if (endType == "COUNT") {
+            binding.etEndCount.text.toString().ifEmpty { "1" }.toInt()
+        } else null
+
+        val repeatEndDate = if (endType == "DATE") {
+            selectedEndDate?.toString() // "yyyy-MM-dd"
+        } else null
+
+        // 3. 데이터 클래스 생성
+        val info = RepeatInfo(
+            repeatType = repeatType,
+            repeatInterval = interval,
+            daysOfWeek = daysOfWeekStr,
+            endType = endType,
+            endCount = endCount,
+            repeatEndDate = repeatEndDate
+        )
+
+        // 4. 결과 전달
+        val description = binding.tvRepeatDescription.text.toString()
+        parentFragmentManager.setFragmentResult("repeatKey", bundleOf(
+            "selectedRepeat" to description,
+            "repeatInfo" to info  // 여기서 RepeatInfo 객체를 넘겨줌
+        ))
+
         parentFragmentManager.popBackStack()
     }
-
     private fun dpToPx(dp: Int): Int = (dp * resources.displayMetrics.density).toInt()
 
     private fun hideKeyboard() {
         val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(view?.windowToken, 0)
     }
+
+    private fun setupLegend() {
+        val daysOfWeek = arrayOf("일", "월", "화", "수", "목", "금", "토")
+        val legendLayout = binding.legendLayout.root as ViewGroup
+        for (i in 0 until legendLayout.childCount) {
+            (legendLayout.getChildAt(i) as? TextView)?.apply {
+                text = daysOfWeek[i]
+                // 가이드에 따른 주말 색상 처리 (선택)
+                if (i == 0) setTextColor(Color.RED)
+                else if (i == 6) setTextColor(Color.BLUE)
+            }
+        }
+    }
+
+    private fun updateDynamicTexts(v: View, type: String) {
+        val dayOfMonth = baseDate.dayOfMonth
+        val monthValue = baseDate.monthValue
+        val dayOfWeekName = baseDate.format(DateTimeFormatter.ofPattern("E요일", Locale.KOREAN))
+
+        // 몇 번째 요일인지 계산 (1~5)
+        val ordinal = (dayOfMonth - 1) / 7 + 1
+        val ordinalNames = listOf("첫 번째", "두 번째", "세 번째", "네 번째", "다섯 번째")
+        val ordinalText = "${ordinalNames[ordinal - 1]} $dayOfWeekName"
+
+        if (type == "MONTHLY") {
+            v.findViewById<RadioButton>(R.id.rb_monthly_day_fixed)?.text = "${dayOfMonth}일마다 반복"
+            v.findViewById<RadioButton>(R.id.rb_monthly_ordinal_day)?.text = "$ordinalText 마다 반복"
+            v.findViewById<RadioButton>(R.id.rb_monthly_day_fixed)?.isChecked = true
+        } else {
+            v.findViewById<RadioButton>(R.id.rb_yearly_day_fixed)?.text = "${monthValue}월 ${dayOfMonth}일마다 반복"
+            v.findViewById<RadioButton>(R.id.rb_yearly_ordinal_day)?.text = "${monthValue}월 $ordinalText 마다 반복"
+            v.findViewById<RadioButton>(R.id.rb_yearly_day_fixed)?.isChecked = true
+        }
+    }
+
+    private fun restorePreviousSettings(info: RepeatInfo) {
+        // 1. 반복 유형 라디오 버튼 선택
+        val typeRbId = when (info.repeatType) {
+            "DAILY" -> R.id.rb_daily
+            "WEEKLY" -> R.id.rb_week
+            "MONTHLY" -> R.id.rb_month
+            "YEARLY" -> R.id.rb_year
+            else -> R.id.rb_none
+        }
+        binding.rgRepeatOptions.check(typeRbId)
+
+        // 2. 세부 설정 복원
+        binding.layoutDynamicDetailContainer.post {
+            val v = detailView ?: return@post
+
+            // 모든 케이스에서 공통적으로 repeatInterval 사용
+            when (info.repeatType) {
+                "DAILY" -> {
+                    v.findViewById<EditText>(R.id.et_daily_interval)?.setText(info.repeatInterval.toString())
+                }
+                "WEEKLY" -> {
+                    v.findViewById<EditText>(R.id.et_week_interval)?.setText(info.repeatInterval.toString())
+
+                    // "MO,WE" -> [1, 3] 형태의 인덱스로 변환하여 체크박스 복구
+                    val dayMap = mapOf("SU" to 0, "MO" to 1, "TU" to 2, "WE" to 3, "TH" to 4, "FR" to 5, "SA" to 6)
+                    val dayIds = listOf(R.id.cb_sun, R.id.cb_mon, R.id.cb_tue, R.id.cb_wed, R.id.cb_thu, R.id.cb_fri, R.id.cb_sat)
+
+                    // 기본 체크 해제 후 저장된 요일만 체크
+                    dayIds.forEach { v.findViewById<CheckBox>(it)?.isChecked = false }
+                    info.daysOfWeek?.split(",")?.forEach { dayCode ->
+                        dayMap[dayCode.trim()]?.let { index ->
+                            v.findViewById<CheckBox>(dayIds[index])?.isChecked = true
+                        }
+                    }
+                }
+                "MONTHLY" -> {
+                    v.findViewById<EditText>(R.id.et_month_interval)?.setText(info.repeatInterval.toString())
+                    updateDynamicTexts(v, "MONTHLY")
+                    // 월간 세부 타입(고정일/요일)은 현재 모델에 없으므로
+                    // 필요시 baseDate 기준으로 기본 라디오 버튼을 체크하게 둡니다.
+                }
+                "YEARLY" -> {
+                    v.findViewById<EditText>(R.id.et_year_interval)?.setText(info.repeatInterval.toString())
+                    updateDynamicTexts(v, "YEARLY")
+                }
+            }
+        }
+
+        // 3. 종료 조건 복원
+        when (info.endType) {
+            "NEVER" -> binding.rgEndOptions.check(R.id.rb_end_never)
+            "COUNT" -> {
+                binding.rgEndOptions.check(R.id.rb_end_count)
+                binding.etEndCount.setText(info.endCount?.toString() ?: "1")
+            }
+            "DATE" -> {
+                binding.rgEndOptions.check(R.id.rb_end_date)
+                // String(yyyy-MM-dd) -> LocalDate 변환
+                info.repeatEndDate?.let {
+                    selectedEndDate = LocalDate.parse(it)
+                    binding.calendarPicker.notifyDateChanged(selectedEndDate!!)
+                }
+            }
+        }
+
+        handleEndLayoutVisibility()
+        updateFullDescription()
+    }
+
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleViewModel.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleViewModel.kt
@@ -27,9 +27,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOn // 추가
 import kotlinx.coroutines.withContext
 import com.example.pace.data.repository.repository.SettingsRepository
+import kotlinx.coroutines.flow.firstOrNull
 
 import javax.inject.Inject
-
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull // searchSchedules에서 필요
 
 @HiltViewModel
 class ScheduleViewModel @Inject constructor(
@@ -163,13 +165,19 @@ class ScheduleViewModel @Inject constructor(
     fun searchSchedules(query: String) {
         lastQuery = query
         val dbQuery = if (query.isBlank()) "%" else "%$query%"
+
         viewModelScope.launch(Dispatchers.IO) {
+            // 💡 현재 룸 DB에 저장된 캘린더 설정값 가져오기
+            val currentSettings = settingsRepository.getUserSettings().firstOrNull()
+            val selectedIds = currentSettings?.syncedCalendarIds ?: emptyList()
+
             val results = repository.searchSchedules(
                 query = dbQuery,
                 colors = _filterColors.value,
                 includeRoute = _filterIncludeRoute.value,
                 startDate = searchStartDate.format(dateFormatter),
-                endDate = searchEndDate.format(dateFormatter)
+                endDate = searchEndDate.format(dateFormatter),
+                selectedIds = selectedIds // 💡 파라미터 전달
             )
             _searchResults.value = results
         }
@@ -186,18 +194,25 @@ class ScheduleViewModel @Inject constructor(
     }
 
     // --- 기존 리스트 가공 및 기타 함수들 ---
-    val scheduleMap: StateFlow<Map<LocalDate, List<Schedule>>> = repository.allSchedules
-        .map { schedules ->
-            schedules.groupBy { schedule ->
-                LocalDate.parse(schedule.startDate, dateFormatter)
-            }
+    val scheduleMap: StateFlow<Map<LocalDate, List<Schedule>>> = combine(
+        repository.allSchedules,
+        settingsRepository.getUserSettings()
+    ) { schedules, settings ->
+        val selectedIds = settings?.syncedCalendarIds ?: emptyList()
+
+        schedules.filter { schedule ->
+            // 💡 백엔드(ROUTE) 일정은 무조건 노출 || 일반 일정은 선택된 캘린더일 때만 노출
+            schedule.type == "ROUTE" || selectedIds.isEmpty() || selectedIds.contains(schedule.calendarId)
+        }.groupBy { schedule ->
+            LocalDate.parse(schedule.startDate, dateFormatter)
         }
-        .flowOn(Dispatchers.IO)
+    }.flowOn(Dispatchers.IO)
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyMap()
         )
+
 
     // 기존의 raw 리스트가 필요한 경우를 위해 유지 (선택 사항)
     val allSchedules = repository.allSchedules
@@ -210,8 +225,13 @@ class ScheduleViewModel @Inject constructor(
                 val token = authDataStore.getAccessToken() ?: return@launch
                 val fullToken = if (token.startsWith("Bearer ")) token else "Bearer $token"
 
+                // [수정] 고정된 날짜 대신 오늘 날짜를 기준으로 설정
+                val today = LocalDate.now().format(dateFormatter)
+                // 종료 날짜는 오늘로부터 1개월 뒤 혹은 1년 뒤 등으로 설정 가능
+                val oneMonthLater = LocalDate.now().plusMonths(1).format(dateFormatter)
+
                 // 1. 서버 데이터를 최신화 (서버->로컬)
-                repository.getScheduleList(fullToken, "2026-02-01", "2026-02-28", null, null)
+                repository.getScheduleList(fullToken, today, oneMonthLater, null, null)
 
                 // 2. [수정] 찌꺼기 청소와 기기 데이터 로드를 순차적으로 실행
                 withContext(Dispatchers.IO) {
@@ -293,25 +313,30 @@ class ScheduleViewModel @Inject constructor(
         endDate: String,
         endTime: String?,
         place: PlaceRequest?,
-        repeatInfo: RepeatInfo? = null,
+        repeatInfo: RepeatInfo? = null, // UI에서 넘어온 반복 정보
         placeId: String? = null,
         customAlarms: List<Int>? = null,
         calendarId: Long? = null,
-        selectedColor: Int // 스펠링 수정: selecetedColor -> selectedColor
+        selectedColor: Int
     ) {
         val settings = userSettings.value
         val reminders = mutableListOf<ReminderRequest>()
 
-        // 1. 알림 설정 로직 (기존 유지)
+        // 1. 알림 설정 로직
         val alarmList = customAlarms ?: settings?.scheduleAlarms ?: emptyList()
         alarmList.forEach { minutes ->
             reminders.add(ReminderRequest(reminderType = "SCHEDULE", minutesBefore = minutes))
         }
-        settings?.departureAlarms?.forEach { minutes ->
-            reminders.add(ReminderRequest(reminderType = "DEPARTURE", minutesBefore = minutes))
+
+        // 2. [보강] 반복 여부 판단 로직 고도화
+        // "안함"을 선택했거나 repeatType이 NONE인 경우 null로 처리하여 에러 방지
+        val finalRepeatInfo = if (repeatInfo?.repeatType?.uppercase() == "NONE") {
+            null
+        } else {
+            repeatInfo
         }
 
-        // 2. Request 객체 생성
+        // 3. Request 객체 생성 (isRepeat 플래그를 repeatInfo 존재 여부와 동기화)
         val request = CreateScheduleRequest(
             title = title,
             isAllDay = isAllDay,
@@ -321,21 +346,42 @@ class ScheduleViewModel @Inject constructor(
             endTime = endTime,
             memo = memo,
             isPathIncluded = (place != null),
-            isRepeat = (repeatInfo != null),
-            repeatInfo = repeatInfo,
+            isRepeat = (finalRepeatInfo != null), // 반복 객체가 있을 때만 true
+            repeatInfo = finalRepeatInfo,
             place = place,
             reminders = reminders,
             route = null
         )
 
-        // 3. 위에서 정의한 createSchedule 함수 호출
+        // 4. 생성 함수 호출
         createSchedule(
             request = request,
             placeId = placeId,
             calendarId = calendarId,
-            selectedColor = selectedColor // 색상 전달
+            selectedColor = selectedColor
         )
     }
+
+    fun getRepeatDescription(info: RepeatInfo?): String {
+        if (info == null || info.repeatType.uppercase() == "NONE") return "반복 안 함"
+
+        val typeStr = when(info.repeatType.uppercase()) {
+            "DAILY" -> "매일"
+            "WEEKLY" -> "매주"
+            "MONTHLY" -> "매월"
+            "YEARLY" -> "매년"
+            else -> ""
+        }
+
+        val endStr = when(info.endType.uppercase()) {
+            "COUNT" -> ", ${info.endCount}회 반복"
+            "DATE" -> ", ${info.repeatEndDate}까지"
+            else -> ""
+        }
+
+        return "$typeStr 반복$endStr"
+    }
+
     // 이벤트 초기화 함수 (연속 호출 방지)
     fun resetCreateEvent() {
         _createScheduleEvent.value = null

--- a/app/src/main/res/layout/fragment_schedule_repeat.xml
+++ b/app/src/main/res/layout/fragment_schedule_repeat.xml
@@ -50,7 +50,6 @@
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/box_schedule"
                 app:cardCornerRadius="12dp"
                 app:cardElevation="0dp">
 
@@ -71,15 +70,10 @@
                         android:paddingEnd="16dp"
                         android:textColor="@color/selector_text_color"
                         android:drawableTint="@color/selector_radio_button"
-                        android:drawableTintMode="src_in"
                         android:background="@null"
-                        android:backgroundTint="@android:color/transparent"
                         android:checked="true"/>
 
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:background="#F1F3F5" />
+                    <View android:layout_width="match_parent" android:layout_height="1dp" android:background="#F1F3F5" />
 
                     <RadioButton
                         android:id="@+id/rb_daily"
@@ -92,14 +86,9 @@
                         android:paddingEnd="16dp"
                         android:textColor="@color/selector_text_color"
                         android:drawableTint="@color/selector_radio_button"
-                        android:background="@null"
-                        android:backgroundTint="@android:color/transparent"
-                        android:drawableTintMode="src_in" />
+                        android:background="@null" />
 
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:background="#F1F3F5" />
+                    <View android:layout_width="match_parent" android:layout_height="1dp" android:background="#F1F3F5" />
 
                     <RadioButton
                         android:id="@+id/rb_week"
@@ -112,14 +101,9 @@
                         android:paddingEnd="16dp"
                         android:textColor="@color/selector_text_color"
                         android:drawableTint="@color/selector_radio_button"
-                        android:background="@null"
-                        android:backgroundTint="@android:color/transparent"
-                        android:drawableTintMode="src_in" />
+                        android:background="@null" />
 
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:background="#F1F3F5" />
+                    <View android:layout_width="match_parent" android:layout_height="1dp" android:background="#F1F3F5" />
 
                     <RadioButton
                         android:id="@+id/rb_month"
@@ -132,14 +116,9 @@
                         android:paddingEnd="16dp"
                         android:textColor="@color/selector_text_color"
                         android:drawableTint="@color/selector_radio_button"
-                        android:background="@null"
-                        android:backgroundTint="@android:color/transparent"
-                        android:drawableTintMode="src_in" />
+                        android:background="@null" />
 
-                    <View
-                        android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:background="#F1F3F5" />
+                    <View android:layout_width="match_parent" android:layout_height="1dp" android:background="#F1F3F5" />
 
                     <RadioButton
                         android:id="@+id/rb_year"
@@ -152,9 +131,7 @@
                         android:paddingEnd="16dp"
                         android:textColor="@color/selector_text_color"
                         android:drawableTint="@color/selector_radio_button"
-                        android:background="@null"
-                        android:backgroundTint="@android:color/transparent"
-                        android:drawableTintMode="src_in" />
+                        android:background="@null" />
                 </RadioGroup>
             </androidx.cardview.widget.CardView>
 
@@ -183,104 +160,129 @@
                 <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@drawable/box_schedule"
                     app:cardCornerRadius="12dp"
                     app:cardElevation="0dp">
 
-                    <RadioGroup
-                        android:id="@+id/rg_end_options"
+                    <androidx.constraintlayout.widget.ConstraintLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:padding="8dp">
 
-                        <RadioButton
-                            android:id="@+id/rb_end_never"
-                            android:layout_width="match_parent"
+                        <RadioGroup
+                            android:id="@+id/rg_end_options"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="24dp"
-                            android:text="계속 진행"
-                            android:button="@null"
-                            android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
-                            android:paddingEnd="16dp"
-                            android:drawableTint="@color/selector_radio_button"
-                            android:drawableTintMode="src_in"
-                            android:background="@null"
-                            android:backgroundTint="@android:color/transparent"
-                            android:checked="true"/>
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent">
 
-                        <View
-                            android:layout_width="match_parent"
-                            android:layout_height="1dp"
-                            android:background="#F1F3F5" />
+                            <RadioButton
+                                android:id="@+id/rb_end_never"
+                                android:layout_width="match_parent"
+                                android:layout_height="56dp"
+                                android:layout_marginStart="24dp"
+                                android:text="계속 진행"
+                                android:button="@null"
+                                android:gravity="center_vertical"
+                                android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
+                                android:paddingEnd="16dp"
+                                android:textColor="@color/selector_text_color"
+                                android:drawableTint="@color/selector_radio_button"
+                                android:background="@null"
+                                android:checked="true"/>
 
-                        <FrameLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content">
+                            <View android:layout_width="match_parent" android:layout_height="1dp" android:background="#F1F3F5" />
 
                             <RadioButton
                                 android:id="@+id/rb_end_count"
                                 android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
+                                android:layout_height="56dp"
                                 android:layout_marginStart="24dp"
-                                android:text=""
+                                android:text="횟수 지정"
                                 android:button="@null"
+                                android:gravity="center_vertical"
                                 android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
                                 android:paddingEnd="16dp"
+                                android:textColor="@color/selector_text_color"
                                 android:drawableTint="@color/selector_radio_button"
                                 android:background="@null" />
 
-                            <LinearLayout
-                                android:id="@+id/layout_count_input"
+                            <View android:layout_width="match_parent" android:layout_height="1dp" android:background="#F1F3F5" />
+
+                            <RadioButton
+                                android:id="@+id/rb_end_date"
+                                android:layout_width="match_parent"
+                                android:layout_height="56dp"
+                                android:layout_marginStart="24dp"
+                                android:text="종료 날짜"
+                                android:button="@null"
+                                android:gravity="center_vertical"
+                                android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
+                                android:paddingEnd="16dp"
+                                android:textColor="@color/selector_text_color"
+                                android:drawableTint="@color/selector_radio_button"
+                                android:background="@null" />
+                        </RadioGroup>
+
+                        <LinearLayout
+                            android:id="@+id/layout_count_input"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:visibility="gone"
+                            app:layout_constraintTop_toTopOf="@id/rg_end_options"
+                            app:layout_constraintStart_toStartOf="@id/rg_end_options"
+                            android:layout_marginTop="68dp"
+                            android:layout_marginStart="24dp"> <EditText
+                            android:id="@+id/et_end_count"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minWidth="30dp"
+                            android:hint="1"
+                            android:inputType="number"
+                            android:background="@null"
+                            android:gravity="start|center_vertical"
+                            android:textColor="@color/black" />
+                            <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_marginStart="10dp"
-                                android:layout_gravity="center_vertical"
-                                android:orientation="horizontal"
-                                android:visibility="visible">
+                                android:text=" 회 반복"
+                                android:textColor="@color/black" />
+                        </LinearLayout>
 
-                                <EditText
-                                    android:id="@+id/et_end_count"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:minWidth="30dp"
-                                    android:hint="1"
-                                    android:inputType="number"
-                                    android:background="@null"
-                                    android:gravity="center"
-                                    android:textColor="@color/black" />
-
-                                <TextView
-                                    android:id="@+id/tv_count_unit"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text=" 회 반복"
-                                    android:textColor="@color/black" />
-                            </LinearLayout>
-                        </FrameLayout>
-
-                        <View
-                            android:layout_width="match_parent"
-                            android:layout_height="1dp"
-                            android:background="#F1F3F5" />
-
-                        <RadioButton
-                            android:id="@+id/rb_end_date"
-                            android:layout_width="match_parent"
+                        <LinearLayout
+                            android:id="@+id/calendarContainer"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="24dp"
-                            android:text="종료 날짜"
-                            android:button="@null"
-                            android:drawableEnd="?android:attr/listChoiceIndicatorSingle"
-                            android:paddingEnd="16dp"
-                            android:drawableTint="@color/selector_radio_button"
-                            android:background="@null"
-                            android:backgroundTint="@android:color/transparent"
-                            android:drawableTintMode="src_in" />
-                    </RadioGroup>
+                            android:orientation="vertical"
+                            android:layout_marginTop="16dp"
+                            android:visibility="gone"
+                            app:layout_constraintTop_toBottomOf="@id/rg_end_options"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent">
+
+                            <RelativeLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:paddingHorizontal="4dp">
+                                <TextView android:id="@+id/tv_current_month" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="2026년 2월" android:textColor="@color/black" android:textSize="16sp" />
+                                <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_alignParentEnd="true">
+                                    <ImageButton android:id="@+id/btn_prev_month" android:layout_width="32dp" android:layout_height="32dp" android:background="?attr/selectableItemBackgroundBorderless" android:src="@drawable/ic_arrow_opened" />
+                                    <ImageButton android:id="@+id/btn_next_month" android:layout_width="32dp" android:layout_height="32dp" android:background="?attr/selectableItemBackgroundBorderless" android:src="@drawable/ic_arrow_closed" />
+                                </LinearLayout>
+                            </RelativeLayout>
+
+                            <include android:id="@+id/legendLayout" layout="@layout/layout_calendar_day_legend" />
+                            <com.kizitonwose.calendar.view.CalendarView
+                                android:id="@+id/calendarPicker"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:overScrollMode="never"
+                                app:cv_dayViewResource="@layout/item_calendar_day_addschedule"
+                                app:cv_scrollPaged="true"
+                                app:cv_orientation="horizontal" />
+                        </LinearLayout>
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
                 </androidx.cardview.widget.CardView>
-
             </LinearLayout>
-
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_repeat_daily.xml
+++ b/app/src/main/res/layout/layout_repeat_daily.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/layout_repeat_interval_daily"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="24dp"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="반복 주기"
+        android:textColor="@color/text_secondary"
+        android:textSize="14sp"
+        android:layout_marginBottom="8dp"/>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardBackgroundColor="@color/white"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="0dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingVertical="16dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:paddingHorizontal="16dp">
+
+                <EditText
+                    android:id="@+id/et_daily_interval"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="24dp"
+                    android:inputType="number"
+                    android:text="1"
+                    android:minWidth="30dp"
+                    android:textAlignment="center"
+                    android:selectAllOnFocus="true"
+                    android:background="@null"
+                    android:textCursorDrawable="@null"
+                    android:textColor="@color/black"
+                    android:textColorHighlight="@android:color/transparent"/>
+
+                <TextView
+                    android:id="@+id/tv_daily_interval_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="일마다"
+                    android:textColor="@color/black" />
+            </LinearLayout>
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/layout/layout_repeat_weekly.xml
+++ b/app/src/main/res/layout/layout_repeat_weekly.xml
@@ -57,7 +57,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:text="일마다"
+                    android:text="주마다"
                     android:textColor="@color/black" />
             </LinearLayout>
 


### PR DESCRIPTION
- [FEAT]
# PR템플릿 

## 변경 사항 요약
- 사용자 온보딩 정보 수정하기에서 백엔드 연동을 해놓긴 했는데, 백엔드의 enum타입 제외하고는 다 잘 되는듯함
- 사용자가 토글로 선택해둔 캘린더들만 일반일정 조회 할 수 있음, 경로일정은 캘린더가 없고 백엔드서버 하나에만 저장해 두기 때문에 
필터에서는 일반일정만 필터링함
- 반복필드 로직을 다 작성하였음, 우리 앱에서 반복일정을 저장해도 삼성캘린더에서 볼 수 있고, 삼성캘린더에서 저장한 반복일정도 우리앱에서 볼 수 있음

## 체크리스트
- [v] 코드 빌드 성공
- [v] 에뮬레이터 실행 시 성공

## 사진올리는곳
![KakaoTalk_20260215_013259683](https://github.com/user-attachments/assets/1af9ddfb-2d22-4628-ab77-1011a8e97fec)
![KakaoTalk_20260215_013259683_01](https://github.com/user-attachments/assets/f0f8e93f-1516-455a-ac43-2a06390ed939)
![KakaoTalk_20260215_013259683_02](https://github.com/user-attachments/assets/f651cc57-cebd-41df-987a-3350f1ccb540)
![KakaoTalk_20260215_013259683_03](https://github.com/user-attachments/assets/53fd98b5-bd11-498d-8f03-e21e7bcfb7fe)
![KakaoTalk_20260215_013259683_04](https://github.com/user-attachments/assets/1bbaf565-4101-4b99-ae3d-21e359c49ddf)
![KakaoTalk_20260215_013259683_05](https://github.com/user-attachments/assets/b2f54676-0807-477c-b20b-4487ddbbbf84)
![KakaoTalk_20260215_013259683_06](https://github.com/user-attachments/assets/db26c2a5-8a15-4113-9fe7-6305f8242cbc)
![KakaoTalk_20260215_013259683_07](https://github.com/user-attachments/assets/cd2ce259-bb3f-4389-a344-eec045e2a5d1)
![KakaoTalk_20260215_013259683_08](https://github.com/user-attachments/assets/bc9dda7b-6952-44bb-85f7-0d4c18dc9499)
