### PR TITLE
[Feat]: 홈 화면에 아이템 바인딩

### DIFF
--- a/app/src/main/java/com/example/pace/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/example/pace/data/db/AppDatabase.kt
@@ -6,9 +6,17 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.example.pace.data.converter.Converters
+import com.example.pace.data.model.Schedule
 import com.example.pace.data.model.UserSettingsEntity
 
-@Database(entities = [UserSettingsEntity::class], version = 1, exportSchema = false)
+@Database(
+    entities = [
+        UserSettingsEntity::class,
+        Schedule::class
+    ],
+    version = 3,
+    exportSchema = false
+)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
 

--- a/app/src/main/java/com/example/pace/data/db/ScheduleDao.kt
+++ b/app/src/main/java/com/example/pace/data/db/ScheduleDao.kt
@@ -67,4 +67,6 @@ interface ScheduleDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSingle(schedule: Schedule)
 
+    @Query("UPDATE schedules SET is_pinned = :pinnedStatus WHERE id = :scheduleId")
+    suspend fun updatePinStatus(scheduleId: Long, pinnedStatus: Boolean)
 }

--- a/app/src/main/java/com/example/pace/data/db/ScheduleDatabase.kt
+++ b/app/src/main/java/com/example/pace/data/db/ScheduleDatabase.kt
@@ -9,10 +9,9 @@ import com.example.pace.data.converter.Converters
 import com.example.pace.data.model.Schedule
 import com.example.pace.data.model.UserSettingsEntity // 👈 1. Import 추가
 
-// 👈 2. entities에 UserSettingsEntity 추가
 @Database(
     entities = [Schedule::class, UserSettingsEntity::class],
-    version = 13, // 👈 3. 구조가 바뀌었으므로 버전을 올립니다 (10 -> 11)
+    version = 14,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/pace/data/model/Schedule.kt
+++ b/app/src/main/java/com/example/pace/data/model/Schedule.kt
@@ -81,7 +81,10 @@ data class Schedule(
     val calendarAccountName: String?,
 
     @ColumnInfo(name = "reminders")
-    val reminders: List<Int> = emptyList(),
+    val reminders: List<Int> = emptyList(), // 일반 일정 알림 (EVENT)
+
+    @ColumnInfo(name = "departure_reminders")
+    val departureReminders: List<Int> = emptyList(), // 출발 알림 (DEPARTURE)
 
     @ColumnInfo(name = "with_route")
     val withRoute: Boolean = false,

--- a/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
@@ -77,5 +77,5 @@ interface ScheduleRepository {
     ): RawDefaultResponse<UpdateScheduleRouteResponse>
 
     suspend fun convertRouteToNormalLocal(scheduleId: Long): Boolean
-
+    suspend fun updatePinStatus(id: Long, isPinned: Boolean)
 }

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
@@ -186,56 +186,60 @@ class ScheduleRepositoryImpl @Inject constructor(
 
     override suspend fun refreshSchedules() {
         try {
-            val systemSchedules = normalDataSource.getSchedules() // 💡 여기서 calendarId를 잘 가져오는지 확인 필요
+            val systemSchedules = normalDataSource.getSchedules()
             val systemIds = systemSchedules.map { it.id }
 
             withContext(Dispatchers.IO) {
-                // 2. 먼저 DB에 최신 데이터를 삽입/업데이트 (이게 먼저 수행되어야 함)
                 if (systemSchedules.isNotEmpty()) {
                     val localSchedulesOnce = scheduleDao.getAllSchedulesOnce()
                     val localScheduleMap = localSchedulesOnce.associateBy { it.id }
 
                     val mergedSchedules = systemSchedules.map { remote ->
                         val local = localScheduleMap[remote.id]
+
                         if (local != null) {
-                            // 💡 시스템 데이터(remote)를 기반으로 하되,
-                            // 로컬에서 관리하던 중요 필드들이 0L이나 기본값이면 local 값을 복사합니다.
+                            // 💡 [핵심] 시스템 데이터(remote)를 업데이트하되,
+                            // 우리 앱 전용 필드(local)는 절대로 잃어버리지 않게 수동으로 다 넣어줍니다.
                             remote.copy(
+                                // 1. 우리 앱의 고유 상태 보존
                                 isPinned = local.isPinned,
-                                // 만약 remote의 calendarId가 0이라면 기존 local의 ID를 유지
+                                isCompleted = local.isCompleted,
+                                isSwiped = local.isSwiped,
+
+                                // 2. [가장 중요] 장소 정보 및 리마인더 보존
+                                placeJson = local.placeJson,
+                                departureReminders = local.departureReminders,
+                                reminders = if (remote.reminders.isEmpty()) local.reminders else remote.reminders,
+
+                                // 3. 타입 정보 유지
+                                type = local.type,
+                                sourceType = local.sourceType,
+                                serverId = local.serverId,
+                                routeId = local.routeId,
+
+                                // 4. 시스템에서 변경될 수 있는 값들은 remote를 따름
                                 calendarId = if (remote.calendarId == 0L) local.calendarId else remote.calendarId,
-                                eventColor = remote.eventColor ?: local.eventColor,
-                                reminders = if (remote.reminders.isEmpty()) local.reminders else remote.reminders
+                                eventColor = remote.eventColor ?: local.eventColor
                             )
                         } else {
                             remote
                         }
                     }
+
+                    // 여기서 insertAll 할 때, 위에 가공된(Pace 데이터가 살아있는) 리스트가 들어감
                     scheduleDao.insertAll(mergedSchedules)
-                    Log.d("SYNC_LOG", "1. 시스템 일정 ${mergedSchedules.size}개 DB 삽입/업데이트 완료")
-                } else {
-                    Log.d("SYNC_LOG", "시스템에서 가져온 리스트가 비어있습니다.")
+                    Log.d("SYNC_LOG", "1. 필드 보존하며 시스템 일정 업데이트 완료")
                 }
 
-                // 3. 이제 DB에 들어간 SYSTEM 데이터와 방금 가져온 systemIds를 비교해서 삭제
-                // NOT IN (시스템ID목록) 쿼리를 실행하여 시스템에 없는 로컬 데이터를 날림
                 if (systemIds.isNotEmpty()) {
                     scheduleDao.deleteRemovedDeviceSchedules(systemIds)
-                    Log.d("SYNC_LOG", "2. 시스템에서 삭제된 일정들 로컬 DB에서 정리 완료")
-                } else {
-                    // 만약 시스템에 일정이 하나도 없다면, 로컬의 모든 SYSTEM 일정을 지워야 함
-                    // 이 부분은 필요에 따라 안전장치를 고려하세요. (전체 삭제 방지 등)
-                    // scheduleDao.deleteAllSystemSchedules() // 필요한 경우 추가
                 }
-
-                // 4. 최종 확인 로그
-                val checkCount = scheduleDao.getSchedulesWithSystemId().size
-                Log.d("SYNC_LOG", "3. 동기화 최종 완료 후 로컬 SYSTEM 개수: $checkCount")
             }
         } catch (e: Exception) {
-            Log.e("SYNC_LOG", "❌ 동기화 중 오류 발생: ${e.message}")
+            Log.e("SYNC_LOG", "❌ 동기화 중 오류: ${e.message}")
         }
     }
+
     override fun getUsedColors(): Flow<List<String>> = scheduleDao.getUsedColorsRaw().map { list ->
         list.mapNotNull { it.color }
     }
@@ -382,7 +386,13 @@ class ScheduleRepositoryImpl @Inject constructor(
                     isAllDay = request.isAllDay,
                     memo = request.memo,
                     location = request.place?.targetName,
-                    placeJson = if (placeId != null) "{\"placeId\":\"$placeId\"}" else null,
+                    placeJson = if (placeId != null) {
+                        "{\"placeId\":\"$placeId\"}"
+                    } else if (request.place != null) {
+                        Gson().toJson(request.place)
+                    } else {
+                        null
+                    },
 
                     // 💡 동적으로 가져온 정보 적용
                     calendarId = targetId,
@@ -428,6 +438,24 @@ class ScheduleRepositoryImpl @Inject constructor(
             if (response.isSuccess && response.result != null) {
                 val serverResult = response.result
                 val info = serverResult.scheduleInfo // 💡 서버가 준 핵심 정보
+                val routeData = serverResult.route // 서버가 준 경로 데이터
+                val gson = Gson()
+                val allReminders = serverResult.reminders ?: emptyList()
+                Log.d("DEBUG_DATA", "전체 리마인더 개수: ${allReminders.size}")
+                val eventReminders = allReminders
+                    .filter { it.reminderType == "EVENT" }
+                    .map { it.minutesBefore }
+
+                val departureReminders = allReminders
+                    .filter { it.reminderType == "DEPARTURE" }
+                    .map { it.minutesBefore }
+                Log.d("DEBUG_DATA", "추출된 출발 알람: $departureReminders")
+                val placeAndRouteJson = if (routeData != null) {
+                    gson.toJson(routeData)
+                } else {
+                    gson.toJson(serverResult.place)
+                }
+                Log.d("DEBUG_DATA", "JSON 생성 여부: ${placeAndRouteJson != null}")
 
                 // 1. 서버가 준 캘린더 ID를 최우선으로 가져옴 (DTO가 String이므로 변환)
                 val serverCalendarId = info.calendarId?.toLongOrNull() ?: calendarId ?: 1L
@@ -459,6 +487,14 @@ class ScheduleRepositoryImpl @Inject constructor(
                     finalColor
                 }
 
+
+                val displayLocation = if (routeData != null) {
+                    // 로그에 찍힌 routeData의 정보를 조합
+                    "${routeData.originName} → ${routeData.destName}"
+                } else {
+                    serverResult.place?.targetName ?: request.place?.targetName ?: info.title ?: "장소 정보 없음"
+                }
+
                 val scheduleToSave = Schedule(
                     id = serverResult.scheduleId, // 서버 ID를 Primary Key로 사용
                     title = info.title,
@@ -468,16 +504,20 @@ class ScheduleRepositoryImpl @Inject constructor(
                     endTime = info.endTime?.take(5) ?: "23:59",
                     isAllDay = info.isAllDay,
                     memo = info.memo,
-                    location = serverResult.place?.targetName ?: request.place?.targetName,
-                    placeJson = if (placeId != null) "{\"placeId\":\"$placeId\"}" else null,
+                    location = displayLocation,
 
-                    // 💡 서버에서 받은 값들을 1:1로 정확히 매핑
+
                     calendarId = serverCalendarId,
                     calendarDisplayName = dName,
                     calendarAccountName = aName,
 
                     eventColor = colorInt,
                     calendarColor = colorInt,
+
+                    reminders = eventReminders,
+                    departureReminders = departureReminders, // 새로 추가한 필드에 저장
+                    placeJson = placeAndRouteJson,
+
                     withRoute = true,
                     type = "ROUTE",
                     sourceType = "SERVER",
@@ -489,20 +529,27 @@ class ScheduleRepositoryImpl @Inject constructor(
                     exDate = null
                 )
 
+                // 💡 [추가] DB 삽입 직전, 객체 내부 상태를 낱낱이 파헤쳐봅시다.
+                Log.d("SAVE_DEBUG", """
+                ========= 삽입 데이터 최종 확인 =========
+                일정 제목: ${scheduleToSave.title}
+                이벤트 리마인더 (EVENT): ${scheduleToSave.reminders}
+                출발 리마인더 (DEPARTURE): ${scheduleToSave.departureReminders}
+                장소(Location): ${scheduleToSave.location}  <-- 이걸 꼭 찍어보세요!
+                장소 JSON (placeJson): ${scheduleToSave.placeJson?.take(100)}... (일부출력)
+                경로 타입 여부: ${scheduleToSave.type}
+                ======================================
+            """.trimIndent())
+
                 // 4. 로컬 DB에 삽입
                 scheduleDao.insertAll(listOf(scheduleToSave))
 
-                Log.d(
-                    "SAVE_FLOW", """
-                [서버 응답 기반 로컬 저장 완료]
-                일정ID: ${scheduleToSave.id}
-                서버가 준 캘린더ID: ${info.calendarId}
-                실제 저장된 캘린더ID: ${scheduleToSave.calendarId}
-                계정명: ${scheduleToSave.calendarAccountName}
-            """.trimIndent()
-                )
+                // 2. [중요] 저장이 끝난 뒤에 성공 응답을 반환합니다.
+                // 하지만 이렇게 해도 ViewModel에서 바로 refresh를 호출하면 덮어쓰기 위험이 있습니다.
+                return@safeApiCall response
+            } else {
+                return@safeApiCall response
             }
-            response
         }
     }
     override fun getCalendarName(calendarId: Long): String? {
@@ -1233,6 +1280,11 @@ class ScheduleRepositoryImpl @Inject constructor(
                 false
             }
         }
+    }
+
+    override suspend fun updatePinStatus(id: Long, isPinned: Boolean) {
+        // DAO의 @Query 함수 호출
+        scheduleDao.updatePinStatus(id, isPinned)
     }
 
 }

--- a/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
@@ -139,23 +139,6 @@ class RouteScheduleFragment : Fragment() {
             // 3. UI 가시성 처리
             binding.deleteRouteIv.visibility = View.VISIBLE
             binding.deleteRouteIv.bringToFront()
-
-            // 4. 데이터 확인용 토스트 (전역 변수 기반으로 출력)
-            Toast.makeText(
-                context,
-                """
-            출발지: $lastStartName
-            출발좌표: $lastStartLat , $lastStartLng
-            
-            도착지: $lastDestName
-            도착좌표: $lastDestLat , $lastDestLng
-            
-            빠른 도착 시간: $earlyArriveTime
-            
-            경로 데이터 파싱 완료
-            """.trimIndent(),
-                Toast.LENGTH_LONG
-            ).show()
         }
     }
     override fun onCreateView(

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleViewModel.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleViewModel.kt
@@ -100,6 +100,15 @@ class ScheduleViewModel @Inject constructor(
     private val _updateScheduleEvent = MutableStateFlow<Boolean?>(null)
     val updateScheduleEvent: StateFlow<Boolean?> = _updateScheduleEvent
 
+    private val _routeDetails = MutableStateFlow<Map<Long, RouteInfo>>(emptyMap())
+
+    // 2. Fragment에서 관찰할 Public StateFlow
+    val routeDetails: StateFlow<Map<Long, RouteInfo>> = _routeDetails
+
+    // 뷰모델 내부
+    private val _scheduleMap = MutableStateFlow<Map<LocalDate, List<Schedule>>>(emptyMap())
+    val scheduleMapLocal: StateFlow<Map<LocalDate, List<Schedule>>> = _scheduleMap
+
     fun setEditMode(enabled: Boolean) {
         _isEditMode.value = enabled
         if (!enabled) _selectedIds.value = emptySet() // 편집 모드 종료 시 선택 초기화
@@ -823,6 +832,60 @@ class ScheduleViewModel @Inject constructor(
             }
         } catch (e: Exception) {
             Log.e("WorkManager", "❌ 예약 실패: ${e.message}")
+        }
+    }
+    fun fetchRouteDetail(scheduleId: Long) {
+        if (_routeDetails.value.containsKey(scheduleId)) return
+
+        viewModelScope.launch {
+            try {
+                // 1. 저장된 액세스 토큰 가져오기 (예시: tokenRepository 또는 SharedPreferences)
+                val accessToken = authDataStore.getAccessToken()
+
+                if (accessToken != null) {
+                    // 2. Repository 호출
+                    val response = repository.getScheduleDetail(accessToken, scheduleId)
+
+                    // 3. 응답 성공 및 데이터 확인
+                    if (response.isSuccess && response.result != null) {
+                        // 서버 응답 바디의 result 안에 route가 있는지 확인
+                        val routeData = response.result.route
+                        if (routeData != null) {
+                            _routeDetails.value = _routeDetails.value + (scheduleId to routeData)
+                        }
+                    }
+                } else {
+                    Log.e("ScheduleViewModel", "AccessToken이 없습니다.")
+                }
+            } catch (e: Exception) {
+                Log.e("ScheduleViewModel", "Route detail fetch failed: ${e.message}")
+            }
+        }
+    }
+
+    fun togglePinLocally(date: LocalDate, scheduleId: Long) {
+        viewModelScope.launch {
+            // 1. 현재 메모리에 있는 리스트에서 해당 스케줄 찾기
+            val currentSchedules = scheduleMap.value[date] ?: return@launch
+            val targetSchedule = currentSchedules.find { it.id == scheduleId } ?: return@launch
+
+            // 2. 새로운 핀 상태 결정
+            val newPinStatus = !targetSchedule.isPinned
+
+            // 3. DB 업데이트 (컬럼 하나만 수정하므로 리마인더 안전!)
+            repository.updatePinStatus(scheduleId, newPinStatus)
+
+            // 4. UI 반영을 위해 StateFlow 업데이트
+            val updatedMap = scheduleMap.value.toMutableMap()
+            val updatedList = currentSchedules.map {
+                if (it.id == scheduleId) it.copy(isPinned = newPinStatus) else it
+            }
+            updatedMap[date] = updatedList
+
+            // _scheduleMap 또는 scheduleMap (Mutable 인 것)에 대입
+            _scheduleMap.value = updatedMap
+
+            Log.d("PinUpdate", "DB 업데이트 완료: ${targetSchedule.title} -> $newPinStatus")
         }
     }
 

--- a/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
@@ -42,6 +42,8 @@ class HomeFragment: Fragment() {
     private lateinit var selectedDate: LocalDate
     private var scheduleMap: Map<LocalDate, List<Schedule>> = emptyMap()
 
+
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -64,8 +66,12 @@ class HomeFragment: Fragment() {
 
     private fun setupRecyclerView() {
         scheduleAdapter = ScheduleRVAdapter(mutableListOf(), requireContext()){ schedule ->
-            val updatedSchedule = schedule.copy(isPinned = !schedule.isPinned)
-            viewModel.updateSchedule(updatedSchedule)
+            // 서버 API를 호출하는 viewModel.updateSchedule 대신
+            // 로컬 데이터만 가공하는 함수를 호출하세요.
+            Log.d("PinClick", "클릭된 일정: ${schedule.title}, 현재 핀 상태: ${schedule.isPinned}")
+
+            viewModel.togglePinLocally(selectedDate, schedule.id)
+            Log.d("PinClick", "클릭된 일정: ${schedule.title}, 나중 핀 상태: ${schedule.isPinned}")
         }
         scheduleTouchHelper = ScheduleTouchHelper(scheduleAdapter)
         val itemTouchHelper = ItemTouchHelper(scheduleTouchHelper)
@@ -211,10 +217,24 @@ class HomeFragment: Fragment() {
     private fun setupObservers() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                // [수정] 가공된 scheduleMap을 관찰합니다.
-                viewModel.scheduleMap.collect { map ->
-                    scheduleMap = map
-                    filterAndDisplaySchedules()
+                // 1. 일정 데이터 관찰
+                launch {
+                    viewModel.scheduleMap.collect { map ->
+                        scheduleMap = map
+                        // 경로 일정이 보이면 API 호출 트리거
+                        map[selectedDate]?.filter { it.type == "ROUTE" }?.forEach {
+                            viewModel.fetchRouteDetail(it.id)
+                        }
+                        filterAndDisplaySchedules()
+                    }
+                }
+
+                // 2. 경로 상세 데이터(API 결과) 관찰
+                launch {
+                    viewModel.routeDetails.collect { _ ->
+                        // 상세 데이터가 들어오면 리스트 다시 그리기
+                        filterAndDisplaySchedules()
+                    }
                 }
             }
         }
@@ -223,6 +243,15 @@ class HomeFragment: Fragment() {
     private fun filterAndDisplaySchedules() {
         // [수정] 복잡한 문자열 포맷팅과 filter 루프 없이 Map에서 즉시 가져옵니다.
         val filteredList = scheduleMap[selectedDate] ?: emptyList()
+
+        filteredList.forEach { schedule ->
+            if (schedule.type == "ROUTE") {
+                viewModel.fetchRouteDetail(schedule.id)
+            }
+        }
+
+        val routeSchedules = filteredList.filter { it.type == "ROUTE" }
+
 
         // 정렬 로직 추가 (필요 시: 고정 -> 시간순)
         val sortedList = filteredList.sortedWith(
@@ -233,7 +262,7 @@ class HomeFragment: Fragment() {
             )
         )
 
-        scheduleAdapter.updateData(sortedList)
+        scheduleAdapter.updateData(sortedList, viewModel.routeDetails.value)
 
         // UI 처리
         if(sortedList.isEmpty()){
@@ -244,4 +273,5 @@ class HomeFragment: Fragment() {
             binding.homeScheduleRv.visibility = View.VISIBLE
         }
     }
+
 }

--- a/app/src/main/java/com/example/pace/ui/main/home/ScheduleRVAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/ScheduleRVAdapter.kt
@@ -2,76 +2,78 @@ package com.example.pace.ui.main.home
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
-import com.example.pace.data.model.Schedule
-import com.example.pace.databinding.ItemScheduleBinding
-import java.time.LocalDate
 import com.example.pace.R
+import com.example.pace.data.model.Schedule
+import com.example.pace.data.model.response.RouteInfo
+import com.example.pace.databinding.ItemScheduleBinding
+
 class ScheduleRVAdapter(
     private var scheduleList: MutableList<Schedule>,
     private val context: Context,
     private val onPinClick: (Schedule) -> Unit,
-): RecyclerView.Adapter<ScheduleRVAdapter.ViewHolder>() {
+) : RecyclerView.Adapter<ScheduleRVAdapter.ViewHolder>() {
+
     lateinit var mOnClickListener: MyOnClickListener
     lateinit var scheduleTouchHelper: ScheduleTouchHelper
 
-    interface MyOnClickListener{
+    private var routeInfoMap: Map<Long, RouteInfo> = emptyMap()
+
+    interface MyOnClickListener {
         fun showModalCase(scheduleList: List<Schedule>, position: Int)
         fun onEdit(schedule: Schedule)
         fun onDelete(schedule: Schedule)
     }
 
-    fun setMyOnClickListener(myOnClickListener: MyOnClickListener){
+    fun setMyOnClickListener(myOnClickListener: MyOnClickListener) {
         mOnClickListener = myOnClickListener
     }
 
     @SuppressLint("NotifyDataSetChanged")
-    fun updateData(newSchedules: List<Schedule>) {
+    fun updateData(newSchedules: List<Schedule>, newRouteMap: Map<Long, RouteInfo> = emptyMap()) {
+        this.routeInfoMap = newRouteMap // 상세 정보 맵 업데이트
         scheduleList.clear()
         scheduleList.addAll(newSchedules)
         notifyDataSetChanged()
     }
 
-    override fun onCreateViewHolder(
-        parent: ViewGroup,
-        viewType: Int
-    ): ViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = ItemScheduleBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        // 데이터 갱신 시 swipe된 거 초기화
-        val viewTop = holder.itemView.findViewById<ConstraintLayout>(R.id.schedule_view_top)
+        val schedule = scheduleList[position]
+
+        // 스와이프 상태 초기화
+        val viewTop = holder.binding.scheduleViewTop
         viewTop.translationX = 0f
 
-        val schedule = scheduleList[position]
         holder.bind(schedule)
 
+        // --- 이벤트 리스너 설정 ---
         holder.binding.schedulePinIv.setOnClickListener {
-            holder.binding.schedulePinnedIv.visibility = View.VISIBLE
             onPinClick(schedule)
             scheduleTouchHelper.closeSwipedMenu(holder)
         }
 
-        // 수정 버튼 (이름 유지: mOnClickListener 사용)
         holder.binding.scheduleEditIv.setOnClickListener {
             mOnClickListener.onEdit(schedule)
             scheduleTouchHelper.closeSwipedMenu(holder)
         }
 
-        // 삭제 버튼 (이름 유지: mOnClickListener 사용)
         holder.binding.scheduleDeleteIv.setOnClickListener {
             mOnClickListener.onDelete(schedule)
             scheduleTouchHelper.closeSwipedMenu(holder)
         }
 
-        holder.binding.scheduleViewTop.setOnClickListener {
-            // 스와이프 상태가 아닐 때만 모달 띄우도록
+        viewTop.setOnClickListener {
             if (viewTop.translationX == 0f) {
                 mOnClickListener.showModalCase(scheduleList, position)
             }
@@ -80,193 +82,88 @@ class ScheduleRVAdapter(
 
     override fun getItemCount(): Int = scheduleList.size
 
-    fun getScheduleAt(position: Int): Schedule {
-        return scheduleList[position]
-    }
 
-    class ScheduleRVAdapter(
-        private var scheduleList: MutableList<Schedule>,
-        private val context: Context,
-        private val onPinClick: (Schedule) -> Unit,
-    ): RecyclerView.Adapter<ScheduleRVAdapter.ViewHolder>() {
-        lateinit var mOnClickListener: MyOnClickListener
-        lateinit var scheduleTouchHelper: ScheduleTouchHelper
-
-        interface MyOnClickListener {
-            fun showModalCase(scheduleList: List<Schedule>, position: Int)
-            fun onEdit(schedule: Schedule)
-            fun onDelete(schedule: Schedule)
-        }
-
-        fun setMyOnClickListener(myOnClickListener: MyOnClickListener) {
-            mOnClickListener = myOnClickListener
-        }
-
-        @SuppressLint("NotifyDataSetChanged")
-        fun updateData(newSchedules: List<Schedule>) {
-            scheduleList.clear()
-            scheduleList.addAll(newSchedules)
-            notifyDataSetChanged()
-        }
-
-        override fun onCreateViewHolder(
-            parent: ViewGroup,
-            viewType: Int
-        ): ViewHolder {
-            val binding =
-                ItemScheduleBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-            return ViewHolder(binding)
-        }
-
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            // 데이터 갱신 시 swipe된 거 초기화
-            val viewTop = holder.itemView.findViewById<ConstraintLayout>(R.id.schedule_view_top)
-            viewTop.translationX = 0f
-
-            val schedule = scheduleList[position]
-            holder.bind(schedule)
-
-            holder.binding.schedulePinIv.setOnClickListener {
-                holder.binding.schedulePinnedIv.visibility = View.VISIBLE
-                onPinClick(schedule)
-                scheduleTouchHelper.closeSwipedMenu(holder)
-            }
-
-            // 수정 버튼 (이름 유지: mOnClickListener 사용)
-            holder.binding.scheduleEditIv.setOnClickListener {
-                mOnClickListener.onEdit(schedule)
-                scheduleTouchHelper.closeSwipedMenu(holder)
-            }
-
-            // 삭제 버튼 (이름 유지: mOnClickListener 사용)
-            holder.binding.scheduleDeleteIv.setOnClickListener {
-                mOnClickListener.onDelete(schedule)
-                scheduleTouchHelper.closeSwipedMenu(holder)
-            }
-
-            holder.binding.scheduleViewTop.setOnClickListener {
-                // 스와이프 상태가 아닐 때만 모달 띄우도록
-                if (viewTop.translationX == 0f) {
-                    mOnClickListener.showModalCase(scheduleList, position)
-                }
-            }
-        }
-
-        override fun getItemCount(): Int = scheduleList.size
-
-        fun getScheduleAt(position: Int): Schedule {
-            return scheduleList[position]
-        }
-
-        inner class ViewHolder(val binding: ItemScheduleBinding) :
-            RecyclerView.ViewHolder(binding.root) {
-            fun bind(schedule: Schedule) {
-                // 체크박스는 HomeFragment에서 사용하지 않으므로 항상 GONE
-                binding.scheduleCheckbox.visibility = View.GONE
-
-                // 1. 이름 (Title)
-                binding.scheduleTitleTv.text = schedule.title ?: "제목 없음"
-
-                // 2. 색상 설정
-                val colorResId = when {
-                    schedule.eventColor != null && schedule.eventColor != 0 -> schedule.eventColor
-                    schedule.calendarColor != null && schedule.calendarColor != 0 -> schedule.calendarColor
-                    else -> android.graphics.Color.parseColor("#A2BD3B") // 기본 색상
-                }
-                binding.scheduleCategoryIv.imageTintList =
-                    android.content.res.ColorStateList.valueOf(colorResId)
-
-                // 3. 시간 표시 (이미 구현되어 있음)
-                if (schedule.isAllDay) {
-                    binding.scheduleTimeTv.text = "하루 종일"
-                } else {
-                    binding.scheduleTimeTv.text = "${schedule.startTime} - ${schedule.endTime}"
-                }
-
-                // 4. 반복 문자열 표시
-                if (!schedule.repeatRule.isNullOrEmpty()) {
-                    binding.scheduleRepeatIv.visibility = View.VISIBLE
-                    binding.scheduleRepeatTv.visibility = View.VISIBLE
-                    // TODO: Schedule 객체에 사람이 읽을 수 있는 반복 문자열 필드가 있다면 그것을 사용.
-                    binding.scheduleRepeatTv.text = "반복 설정됨"
-                } else {
-                    binding.scheduleRepeatIv.visibility = View.GONE
-                    binding.scheduleRepeatTv.visibility = View.GONE
-                }
-
-                // 5. 장소 표시
-                if (!schedule.location.isNullOrEmpty()) {
-                    binding.scheduleNormalLocationLl.visibility = View.VISIBLE
-                    binding.scheduleNormalLocationIv.visibility = View.VISIBLE
-                    binding.scheduleNormalLocationTv.text = schedule.location
-                    binding.scheduleRouteLocationLl.visibility =
-                        View.GONE // HomeFragment에서는 경로 위치 숨김
-                } else {
-                    binding.scheduleNormalLocationLl.visibility = View.GONE
-                    binding.scheduleNormalLocationIv.visibility = View.GONE
-                    binding.scheduleNormalLocationTv.text = "" // 텍스트도 비워둠
-                    binding.scheduleRouteLocationLl.visibility =
-                        View.GONE // 항상 숨김 (route type이 아니므로)
-                }
-
-                // 고정 아이콘 (isPinned 상태에 따라)
-                binding.schedulePinnedIv.visibility =
-                    if (schedule.isPinned) View.VISIBLE else View.GONE
-                binding.scheduleAlertTv.visibility = View.GONE
-            }
-        }
-    }
-
-    inner class ViewHolder(val binding: ItemScheduleBinding): RecyclerView.ViewHolder(binding.root){
-        fun bind(schedule: Schedule){
-            // 체크박스는 HomeFragment에서 사용하지 않으므로 항상 GONE
+    inner class ViewHolder(val binding: ItemScheduleBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(schedule: Schedule) {
             binding.scheduleCheckbox.visibility = View.GONE
-
-            // 1. 이름 (Title)
             binding.scheduleTitleTv.text = schedule.title ?: "제목 없음"
 
-            // 2. 색상 설정
+            // 1. 색상 설정
             val colorResId = when {
                 schedule.eventColor != null && schedule.eventColor != 0 -> schedule.eventColor
                 schedule.calendarColor != null && schedule.calendarColor != 0 -> schedule.calendarColor
-                else -> android.graphics.Color.parseColor("#A2BD3B") // 기본 색상
+                else -> Color.parseColor("#A2BD3B")
             }
-            binding.scheduleCategoryIv.imageTintList = android.content.res.ColorStateList.valueOf(colorResId)
+            binding.scheduleCategoryIv.imageTintList = ColorStateList.valueOf(colorResId)
 
-            // 3. 시간 표시 (이미 구현되어 있음)
-            if (schedule.isAllDay) {
-                binding.scheduleTimeTv.text = "하루 종일"
-            } else {
-                binding.scheduleTimeTv.text = "${schedule.startTime} - ${schedule.endTime}"
-            }
+            // 2. 시간 표시
+            binding.scheduleTimeTv.text = if (schedule.isAllDay) "하루 종일" else "${schedule.startTime} - ${schedule.endTime}"
 
-            // 4. 반복 문자열 표시
+            // 3. 고정 및 반복 표시
+            binding.schedulePinnedIv.visibility = if (schedule.isPinned) View.VISIBLE else View.GONE
             if (!schedule.repeatRule.isNullOrEmpty()) {
                 binding.scheduleRepeatIv.visibility = View.VISIBLE
                 binding.scheduleRepeatTv.visibility = View.VISIBLE
-                // TODO: Schedule 객체에 사람이 읽을 수 있는 반복 문자열 필드가 있다면 그것을 사용.
                 binding.scheduleRepeatTv.text = "반복 설정됨"
             } else {
                 binding.scheduleRepeatIv.visibility = View.GONE
                 binding.scheduleRepeatTv.visibility = View.GONE
             }
 
-            // 5. 장소 표시
-            if (!schedule.location.isNullOrEmpty()) {
-                binding.scheduleNormalLocationLl.visibility = View.VISIBLE
-                binding.scheduleNormalLocationIv.visibility = View.VISIBLE
-                binding.scheduleNormalLocationTv.text = schedule.location
-                binding.scheduleRouteLocationLl.visibility = View.GONE // HomeFragment에서는 경로 위치 숨김
-            } else {
-                binding.scheduleNormalLocationLl.visibility = View.GONE
-                binding.scheduleNormalLocationIv.visibility = View.GONE
-                binding.scheduleNormalLocationTv.text = "" // 텍스트도 비워둠
-                binding.scheduleRouteLocationLl.visibility = View.GONE // 항상 숨김 (route type이 아니므로)
-            }
+            val routeDetail = routeInfoMap[schedule.id]
 
-            // 고정 아이콘 (isPinned 상태에 따라)
-            binding.schedulePinnedIv.visibility = if (schedule.isPinned) View.VISIBLE else View.GONE
-            binding.scheduleAlertTv.visibility = View.GONE
+            if (schedule.type == "ROUTE") {
+                binding.scheduleNormalLocationLl.visibility = View.GONE
+                binding.scheduleRouteLocationLl.visibility = View.VISIBLE
+
+                if (routeDetail != null) {
+                    // 1. 위치 정보: 출발지 -> 목적지
+                    binding.scheduleRouteNameTv.text = "${routeDetail.originName} → ${routeDetail.destName}"
+
+                    // 1. 시간 계산 (9시간 더하기)
+                    val formatter = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+
+                    // 출발 시간 처리
+                    val startTime = routeDetail.departureTime?.let {
+                        java.time.LocalDateTime.parse(it) // ISO_DATE_TIME 파싱
+                            .plusHours(9)                // 9시간 더하기
+                            .format(formatter)           // HH:mm 포맷팅
+                    } ?: "00:00"
+
+                    // 도착 시간 처리
+                    val endTime = routeDetail.arrivalTime?.let {
+                        java.time.LocalDateTime.parse(it)
+                            .plusHours(9)
+                            .format(formatter)
+                    } ?: "00:00"
+
+                    binding.scheduleRouteRangeTv.text = "$startTime - $endTime"
+
+                    // 3. 소요 시간 가공 (0시간 00분 형식)
+                    val totalSeconds = routeDetail.totalTime
+                    val hours = totalSeconds / 3600
+                    val minutes = (totalSeconds % 3600) / 60
+
+                    // 항상 "0시간 00분" 형식을 유지하도록 설정
+                    val durationFormatted = "${hours}시간 ${minutes}분"
+                    binding.scheduleRouteDurationTv.text = durationFormatted
+
+                } else {
+                    // 데이터 로딩 중 Placeholder
+                    binding.scheduleRouteNameTv.text = schedule.location ?: "경로를 불러오는 중..."
+                    binding.scheduleRouteRangeTv.text = "${schedule.startTime} - ${schedule.endTime}"
+                    binding.scheduleRouteDurationTv.text = "0시간 0분"
+                }
+            } else {
+                // 일반 일정 처리 (기존과 동일)
+                binding.scheduleRouteLocationLl.visibility = View.GONE
+                if (!schedule.location.isNullOrEmpty()) {
+                    binding.scheduleNormalLocationLl.visibility = View.VISIBLE
+                    binding.scheduleNormalLocationTv.text = schedule.location
+                } else {
+                    binding.scheduleNormalLocationLl.visibility = View.GONE
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- [FEAT]
# PR템플릿 

## 변경 사항 요약
- 아이템들의 정보를 홈화면에 바인딩하였습니다

- 일정을 생성할 때 일반일정은 멀쩡한데 경로일정을 생성 시 룸db에 리마인더와 경로필드가 들어가지 않는 것을 발견하였습니다
그래서 경로일정의 경우 반드시 서버의 일정 상세조회 api를 호출하여 데이터를 받아오는거로 하였습니다
원인으로는 두가지 정도를 생각하였는데 첫번째로는 데이터 파싱을 잘 못하여 이상하게 들어가는것
두번째로는 캘린더 프로바이더에서 이미 만들어져있던 id가 있었던 것 두가지 정도를 생각해봤는데, 둘다 될 수 없는 이유가 있어서
원인을 명확하게 파악하지 못한 상태입니다.

- 핀 고정 기능에 대하여 기존에 작성되어있던 updateSchedule대신에 다른 함수를 만들어서 동작하도록 해두었습니다.
기존에 잘 안들어간 리마인더를 덮어쓰기 때문에, 핀 기능을 클릭하면 리마인더와 캘린더 필드가 초기화 되는 문제가 있었습니다.


## 체크리스트
- [v] 코드 빌드 성공
- [v] 에뮬레이터 실행 시 성공

## 사진올리는곳
![Screenshot_20260219_012721_Pace](https://github.com/user-attachments/assets/1c09fe84-603c-4c50-b879-6693f3b24458)
![Screenshot_20260219_012726_Pace](https://github.com/user-attachments/assets/5164ec14-f91a-47c0-bceb-9e4324559534)
![image0](https://github.com/user-attachments/assets/4c08a5a1-bfab-4320-897f-f50bff8246d7)
