### PR TITLE
[Refactor]: 격자모양 캘린더 아이템 배치와 반복일정 로직 보강, 백엔드 리퀘스트 수정

### DIFF
--- a/app/src/main/java/com/example/pace/data/api/ScheduleService.kt
+++ b/app/src/main/java/com/example/pace/data/api/ScheduleService.kt
@@ -1,6 +1,6 @@
 package com.example.pace.data.api
 
-import com.example.pace.data.model.request.CreateScheduleRequest
+import com.example.pace.data.model.request.CreateRouteScheduleRequest
 import com.example.pace.data.model.request.DeleteScheduleRequest
 import com.example.pace.data.model.request.UpdateRouteRequest
 import com.example.pace.data.model.request.UpdateScheduleEditRouteRequest
@@ -50,9 +50,9 @@ interface ScheduleService {
     ): RawDefaultResponse<SchedulePagingResponse>
 
     @POST("/api/v1/schedules")
-    suspend fun createSchedule(
+    suspend fun createRouteSchedule(
         @Header("Authorization") accessToken: String,
-        @Body request: CreateScheduleRequest
+        @Body request: CreateRouteScheduleRequest
     ): RawDefaultResponse<CreateScheduleResponse>
 
     @HTTP(method = "DELETE", path = "/api/v1/schedules", hasBody = true)
@@ -82,7 +82,7 @@ interface ScheduleService {
         @Header("Authorization") accessToken: String,
         @Path("scheduleId") scheduleId: Long,
         @Query("scope") scope: String = "SINGLE",
-        @Body request: CreateScheduleRequest // 바디 타입 확인!
+        @Body request: CreateRouteScheduleRequest // 바디 타입 확인!
     ): RawDefaultResponse<CreateScheduleResponse>
 
     @PATCH("/api/v1/schedules/{id}/conversion")

--- a/app/src/main/java/com/example/pace/data/datasource/NormalScheduleRemoteDataSource.kt
+++ b/app/src/main/java/com/example/pace/data/datasource/NormalScheduleRemoteDataSource.kt
@@ -11,12 +11,18 @@ import com.example.pace.data.model.request.RepeatInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.*
 import dagger.hilt.android.qualifiers.ApplicationContext // 추가
 import javax.inject.Inject // 추가
 class NormalScheduleRemoteDataSource @Inject constructor(
     @ApplicationContext private val applicationContext: Context
 ) {
+    companion object {
+        private const val REPEAT_DEBUG_TAG = "RepeatDebug"
+    }
+
     suspend fun insertToCalendarProvider(
         request: CreateScheduleRequest,
         selectedCalendarId: Long? = null,
@@ -24,20 +30,34 @@ class NormalScheduleRemoteDataSource @Inject constructor(
     ): Long = withContext(Dispatchers.IO) {
         val contentResolver = applicationContext.contentResolver
 
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
-        val startMillis = sdf.parse("${request.startDate} ${request.startTime ?: "00:00"}")?.time ?: System.currentTimeMillis()
-        val endMillis = sdf.parse("${request.endDate} ${request.endTime ?: "23:59"}")?.time ?: (startMillis + 3600000)
+        val timing = buildCalendarEventTiming(
+            startDate = request.startDate,
+            endDate = request.endDate,
+            startTime = request.startTime,
+            endTime = request.endTime,
+            isAllDay = request.isAllDay
+        )
 
         val generatedRrule = buildRRule(request.repeatInfo)
+        if (generatedRrule != null) {
+            Log.d(
+                REPEAT_DEBUG_TAG,
+                "반복 저장 요청: title=${request.title}, isAllDay=${request.isAllDay}, startDate=${request.startDate}, endDate=${request.endDate}, startTime=${request.startTime}, endTime=${request.endTime}, repeatInfo=${request.repeatInfo}"
+            )
+            Log.d(
+                REPEAT_DEBUG_TAG,
+                "반복 저장 값: dtStart=${timing.startMillis}, dtEnd=${timing.endMillis}, duration=${timing.durationForRecurring}, timezone=${timing.timeZoneId}, rrule=$generatedRrule"
+            )
+        }
 
         val values = ContentValues().apply {
             put(CalendarContract.Events.TITLE, request.title)
             put(CalendarContract.Events.DESCRIPTION, request.memo)
             put(CalendarContract.Events.EVENT_LOCATION, request.place?.targetName ?: "")
-            put(CalendarContract.Events.DTSTART, startMillis)
+            put(CalendarContract.Events.DTSTART, timing.startMillis)
             put(CalendarContract.Events.ALL_DAY, if (request.isAllDay) 1 else 0)
             put(CalendarContract.Events.CALENDAR_ID, selectedCalendarId ?: 1L)
-            put(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
+            put(CalendarContract.Events.EVENT_TIMEZONE, timing.timeZoneId)
 
             // [색상 처리]
             val finalColor = if (selectedColor != null && selectedColor != 0) selectedColor
@@ -49,13 +69,12 @@ class NormalScheduleRemoteDataSource @Inject constructor(
                 put(CalendarContract.Events.RRULE, generatedRrule)
 
                 // 반복 일정은 DTEND 대신 DURATION 사용 권장 (P3600S = 3600초 = 1시간)
-                val durationSeconds = (endMillis - startMillis) / 1000
-                put(CalendarContract.Events.DURATION, "P${durationSeconds}S")
+                put(CalendarContract.Events.DURATION, timing.durationForRecurring)
                 // 반복 일정 시 DTEND는 null로 비워두는 것이 표준입니다.
                 putNull(CalendarContract.Events.DTEND)
             } else {
                 // 반복이 아닐 때는 일반적인 DTEND 사용
-                put(CalendarContract.Events.DTEND, endMillis)
+                put(CalendarContract.Events.DTEND, timing.endMillis)
             }
 
             put(CalendarContract.Events.HAS_ALARM, if (request.reminders.isNotEmpty()) 1 else 0)
@@ -184,6 +203,15 @@ class NormalScheduleRemoteDataSource @Inject constructor(
                     }
 
                     val isAllDay = it.getInt(allDayIdx) == 1
+                    val normalizedEndMillis = normalizeEndMillisForDisplay(
+                        startMillis = dtStart,
+                        endMillis = dtEnd,
+                        isAllDay = isAllDay
+                    )
+                    val startDate = if (isAllDay) formatMillisToUtcDate(dtStart) else formatMillisToDate(dtStart)
+                    val endDate = if (isAllDay) formatMillisToUtcDate(normalizedEndMillis) else formatMillisToDate(normalizedEndMillis)
+                    val startTime = if (isAllDay) "00:00" else formatMillisToTime(dtStart)
+                    val endTime = if (isAllDay) "23:59" else formatMillisToTime(normalizedEndMillis)
                     val memo = it.getString(descIdx)
                     val location = it.getString(locIdx)
                     val rrule = it.getString(rruleIdx)
@@ -194,6 +222,12 @@ class NormalScheduleRemoteDataSource @Inject constructor(
                     val calendarColor = it.getInt(calColorIdx)
 
                     val reminders = fetchReminders(id)
+                    if (!rrule.isNullOrEmpty()) {
+                        Log.d(
+                            REPEAT_DEBUG_TAG,
+                            "반복 조회 값: id=$id, title=$title, dtStart=$dtStart, rawDtEnd=$dtEnd, duration=$durationStr, isAllDay=$isAllDay, startDate=$startDate, endDate=$endDate, startTime=$startTime, endTime=$endTime, rrule=$rrule"
+                        )
+                    }
 
                     scheduleList.add(
                         Schedule(
@@ -201,10 +235,10 @@ class NormalScheduleRemoteDataSource @Inject constructor(
                             originalId = originalId,
                             status = status,
                             title = title,
-                            startDate = formatMillisToDate(dtStart),
-                            endDate = formatMillisToDate(dtEnd),
-                            startTime = formatMillisToTime(dtStart),
-                            endTime = formatMillisToTime(dtEnd),
+                            startDate = startDate,
+                            endDate = endDate,
+                            startTime = startTime,
+                            endTime = endTime,
                             isAllDay = isAllDay,
                             memo = memo,
                             location = location,
@@ -255,9 +289,79 @@ class NormalScheduleRemoteDataSource @Inject constructor(
         return sdf.format(Date(millis))
     }
 
+    private fun formatMillisToUtcDate(millis: Long): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        return sdf.format(Date(millis))
+    }
+
     private fun formatMillisToTime(millis: Long): String {
         val sdf = SimpleDateFormat("HH:mm", Locale.getDefault())
         return sdf.format(Date(millis))
+    }
+
+    private fun normalizeEndMillisForDisplay(
+        startMillis: Long,
+        endMillis: Long,
+        isAllDay: Boolean
+    ): Long {
+        if (!isAllDay || endMillis <= startMillis) return endMillis
+
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+            timeInMillis = endMillis
+        }
+        val isExclusiveMidnightEnd = calendar.get(Calendar.HOUR_OF_DAY) == 0 &&
+            calendar.get(Calendar.MINUTE) == 0 &&
+            calendar.get(Calendar.SECOND) == 0
+
+        return if (isExclusiveMidnightEnd) {
+            endMillis - 1L
+        } else {
+            endMillis
+        }
+    }
+
+    private data class CalendarEventTiming(
+        val startMillis: Long,
+        val endMillis: Long,
+        val durationForRecurring: String,
+        val timeZoneId: String
+    )
+
+    private fun buildCalendarEventTiming(
+        startDate: String,
+        endDate: String,
+        startTime: String?,
+        endTime: String?,
+        isAllDay: Boolean
+    ): CalendarEventTiming {
+        return if (isAllDay) {
+            val startLocalDate = LocalDate.parse(startDate)
+            val endLocalDate = LocalDate.parse(endDate)
+            val startMillis = startLocalDate.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli()
+            val endMillis = endLocalDate.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli()
+            val inclusiveDays = java.time.temporal.ChronoUnit.DAYS.between(startLocalDate, endLocalDate).toInt() + 1
+
+            CalendarEventTiming(
+                startMillis = startMillis,
+                endMillis = endMillis,
+                durationForRecurring = "P${inclusiveDays}D",
+                timeZoneId = "UTC"
+            )
+        } else {
+            val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+            val startMillis = sdf.parse("$startDate ${startTime ?: "00:00"}")?.time ?: System.currentTimeMillis()
+            val endMillis = sdf.parse("$endDate ${endTime ?: "23:59"}")?.time ?: (startMillis + 3600000)
+            val durationSeconds = ((endMillis - startMillis) / 1000).coerceAtLeast(0)
+
+            CalendarEventTiming(
+                startMillis = startMillis,
+                endMillis = endMillis,
+                durationForRecurring = "P${durationSeconds}S",
+                timeZoneId = TimeZone.getDefault().id
+            )
+        }
     }
 
     // rrule에 맞춰서 변환
@@ -306,23 +410,22 @@ class NormalScheduleRemoteDataSource @Inject constructor(
         val contentResolver = applicationContext.contentResolver
 
         // 1. 날짜 및 시간 파싱 (기존 로직 유지)
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
-        val startMillis = try {
-            sdf.parse("${schedule.startDate} ${schedule.startTime ?: "00:00"}")?.time ?: System.currentTimeMillis()
-        } catch (e: Exception) { System.currentTimeMillis() }
-
-        val endMillis = try {
-            sdf.parse("${schedule.endDate} ${schedule.endTime ?: "23:59"}")?.time ?: startMillis
-        } catch (e: Exception) { startMillis }
+        val timing = buildCalendarEventTiming(
+            startDate = schedule.startDate,
+            endDate = schedule.endDate,
+            startTime = schedule.startTime,
+            endTime = schedule.endTime,
+            isAllDay = schedule.isAllDay
+        )
         Log.d("CALENDAR_UPDATE", "수정 시도 - 제목: ${schedule.title}, 장소: ${schedule.location}")
         // 2. 업데이트할 데이터 세팅
         val values = ContentValues().apply {
             put(CalendarContract.Events.TITLE, schedule.title)
             put(CalendarContract.Events.DESCRIPTION, schedule.memo)
             put(CalendarContract.Events.EVENT_LOCATION, schedule.location ?: "")
-            put(CalendarContract.Events.DTSTART, startMillis)
+            put(CalendarContract.Events.DTSTART, timing.startMillis)
             put(CalendarContract.Events.ALL_DAY, if (schedule.isAllDay) 1 else 0)
-            put(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
+            put(CalendarContract.Events.EVENT_TIMEZONE, timing.timeZoneId)
 
             // 💡 [해결 1] 캘린더 ID 명시적 업데이트 (중요!)
             put(CalendarContract.Events.CALENDAR_ID, schedule.calendarId)
@@ -334,11 +437,10 @@ class NormalScheduleRemoteDataSource @Inject constructor(
 
             if (!schedule.repeatRule.isNullOrEmpty()) {
                 put(CalendarContract.Events.RRULE, schedule.repeatRule)
-                val durationSeconds = (endMillis - startMillis) / 1000
-                put(CalendarContract.Events.DURATION, "P${durationSeconds}S")
+                put(CalendarContract.Events.DURATION, timing.durationForRecurring)
                 putNull(CalendarContract.Events.DTEND)
             } else {
-                put(CalendarContract.Events.DTEND, endMillis)
+                put(CalendarContract.Events.DTEND, timing.endMillis)
                 putNull(CalendarContract.Events.DURATION)
                 putNull(CalendarContract.Events.RRULE)
             }

--- a/app/src/main/java/com/example/pace/data/datasource/RouteScheduleRemoteDataSource.kt
+++ b/app/src/main/java/com/example/pace/data/datasource/RouteScheduleRemoteDataSource.kt
@@ -1,24 +1,17 @@
 package com.example.pace.data.datasource
 
-import android.provider.CalendarContract
 import com.example.pace.data.api.ScheduleService
-import com.example.pace.data.model.request.CreateScheduleRequest
 import com.example.pace.data.model.request.DeleteScheduleRequest
 import com.example.pace.data.model.request.UpdateScheduleRequest
 import com.example.pace.data.model.request.UpdateScheduleRouteRequest
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class RouteScheduleRemoteDataSource @Inject constructor(
-    private val scheduleService: ScheduleService,
-    // 💡 context를 생성자에서 주입받습니다.
-    @dagger.hilt.android.qualifiers.ApplicationContext private val context: android.content.Context
+    private val scheduleService: ScheduleService
 ) {
 
-    // 1. 전체 일정 목록 가져오기 (페이징)
     suspend fun getScheduleList(
         token: String,
         startDate: String,
@@ -27,15 +20,9 @@ class RouteScheduleRemoteDataSource @Inject constructor(
         lastId: Long? = null
     ) = scheduleService.getScheduleList(token, startDate, endDate, lastDate, lastId)
 
-    // 2. 새로운 일정 생성
-    suspend fun createSchedule(token: String, request: CreateScheduleRequest) =
-        scheduleService.createSchedule(token, request)
-
-    // 3. 일정 상세 정보 조회
     suspend fun getScheduleDetail(token: String, scheduleId: Long) =
         scheduleService.getScheduleDetail(token, scheduleId)
 
-    // 4. 일정 수정
     suspend fun updateSchedule(
         token: String,
         scheduleId: Long,
@@ -43,65 +30,18 @@ class RouteScheduleRemoteDataSource @Inject constructor(
         request: UpdateScheduleRequest
     ) = scheduleService.updateSchedule(token, scheduleId, scope, request)
 
-    // 5. 일정 삭제 (여러 개 선택 삭제 가능)
     suspend fun deleteSchedules(token: String, request: DeleteScheduleRequest) =
         scheduleService.deleteSchedules(token, request)
 
-    // 6. 일정 내 경로 수정
     suspend fun updateScheduleRoute(
         token: String,
         scheduleId: Long,
         request: UpdateScheduleRouteRequest
     ) = scheduleService.updateScheduleRoute(token, scheduleId, request)
 
-    // 7. 일정 내 경로 삭제
     suspend fun deleteScheduleRoute(token: String, scheduleId: Long) =
         scheduleService.deleteScheduleRoute(token, scheduleId)
 
-    // 8. 경로 일정을 일반 일정으로 변환
     suspend fun convertRouteToGeneral(token: String, id: Long) =
         scheduleService.convertRouteToGeneral(token, id)
-
-    suspend fun insertToCalendarProvider(request: CreateScheduleRequest): Long = withContext(
-        Dispatchers.IO) {
-        // 💡 applicationContext 대신 주입받은 context를 사용합니다.
-        val contentResolver = context.contentResolver
-
-        val startMillis = parseToMillis(request.startDate, request.startTime ?: "00:00")
-        val endMillis = parseToMillis(request.endDate, request.endTime ?: "23:59")
-
-        val values = android.content.ContentValues().apply {
-            put(CalendarContract.Events.TITLE, request.title)
-            put(CalendarContract.Events.DESCRIPTION, request.memo)
-            put(CalendarContract.Events.DTSTART, startMillis)
-            put(CalendarContract.Events.DTEND, endMillis)
-            put(CalendarContract.Events.ALL_DAY, if (request.isAllDay) 1 else 0)
-            put(CalendarContract.Events.CALENDAR_ID, 1)
-            put(CalendarContract.Events.EVENT_TIMEZONE, java.util.TimeZone.getDefault().id)
-        }
-
-        val uri = contentResolver.insert(CalendarContract.Events.CONTENT_URI, values)
-        val eventId = uri?.lastPathSegment?.toLong() ?: -1L
-
-        if (eventId != -1L) {
-            request.reminders.forEach { reminder ->
-                val reminderValues = android.content.ContentValues().apply {
-                    put(CalendarContract.Reminders.MINUTES, reminder.minutesBefore)
-                    put(CalendarContract.Reminders.EVENT_ID, eventId)
-                    put(CalendarContract.Reminders.METHOD, CalendarContract.Reminders.METHOD_ALERT)
-                }
-                contentResolver.insert(CalendarContract.Reminders.CONTENT_URI, reminderValues)
-            }
-        }
-        eventId
-    }
-    private fun parseToMillis(date: String, time: String): Long {
-        return try {
-            val dateTime = "$date $time"
-            val sdf = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.getDefault())
-            sdf.parse(dateTime)?.time ?: System.currentTimeMillis()
-        } catch (e: Exception) {
-            System.currentTimeMillis()
-        }
-    }
 }

--- a/app/src/main/java/com/example/pace/data/model/request/ScheduleRequest.kt
+++ b/app/src/main/java/com/example/pace/data/model/request/ScheduleRequest.kt
@@ -47,6 +47,21 @@ data class CreateScheduleRequest(
     @SerializedName("route") val route: RouteRequest?
 )
 
+data class CreateRouteScheduleRequest(
+    @SerializedName("title") val title: String,
+    @SerializedName("startDate") val startDate: String,
+    @SerializedName("endDate") val endDate: String,
+    @SerializedName("startTime") val startTime: String?,
+    @SerializedName("endTime") val endTime: String?,
+    @SerializedName("calendarId") val calendarId: String?,
+    @SerializedName("color") val color: String? = "#DC354B",
+    @SerializedName("memo") val memo: String?,
+    @SerializedName("isPathIncluded") val isPathIncluded: Boolean,
+    @SerializedName("place") val place: PlaceRequest?,
+    @SerializedName("reminders") val reminders: List<ReminderRequest>,
+    @SerializedName("route") val route: RouteRequest
+)
+
 
 data class RepeatInfo(
     @SerializedName("repeatType") val repeatType: String,      // DAILY, WEEKLY, MONTHLY, YEARLY, NONE

--- a/app/src/main/java/com/example/pace/data/model/response/ScheduleResponse.kt
+++ b/app/src/main/java/com/example/pace/data/model/response/ScheduleResponse.kt
@@ -48,7 +48,7 @@ data class ScheduleItem(
 
 data class ScheduleInfo(
     @SerializedName("title") val title: String,
-    @SerializedName("isAllDay") val isAllDay: Boolean,
+    @SerializedName("isAllDay") val isAllDay: Boolean = false,
     @SerializedName("startDate") val startDate: String,
     @SerializedName("endDate") val endDate: String,
     @SerializedName("startTime") val startTime: String?,

--- a/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
@@ -15,6 +15,7 @@ interface ScheduleRepository {
 
     fun getUsedColors(): Flow<List<String>>
     fun getCalendarName(calendarId: Long): String?
+    fun getCalendarColor(calendarId: Long): Int?
 
     suspend fun searchSchedules(
         query: String,

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
@@ -563,6 +563,17 @@ class ScheduleRepositoryImpl @Inject constructor(
         }
     }
 
+    override fun getCalendarColor(calendarId: Long): Int? {
+        val projection = arrayOf(CalendarContract.Calendars.CALENDAR_COLOR)
+        val uri = CalendarContract.Calendars.CONTENT_URI
+        val selection = "${CalendarContract.Calendars._ID} = ?"
+        val selectionArgs = arrayOf(calendarId.toString())
+
+        return context.contentResolver.query(uri, projection, selection, selectionArgs, null)?.use { cursor ->
+            if (cursor.moveToFirst()) cursor.getInt(0) else null
+        }
+    }
+
     // --- 반복 일정 전개 및 헬퍼 함수 (기존 유지) ---
     private fun expandSchedules(rawSchedules: List<Schedule>): List<Schedule> {
         val expandedList = mutableListOf<Schedule>()

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
@@ -26,6 +26,7 @@ import com.example.pace.data.model.response.*
 import com.example.pace.data.repository.repository.ScheduleRepository
 import com.example.pace.data.util.safeApiCall
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -34,8 +35,13 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.util.*
 import javax.inject.Inject
 import kotlin.code
@@ -48,6 +54,15 @@ class ScheduleRepositoryImpl @Inject constructor(
     private val authDataStore: AuthDataStore,
     @ApplicationContext private val context: Context
 ) : ScheduleRepository {
+
+    companion object {
+        private val ROUTE_SOURCE_ZONE: ZoneId = ZoneId.of("Asia/Seoul")
+        private val UTC_API_TIME_FORMATTER: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        private const val SWAGGER_LOG_TAG = "SwaggerScheduleRequest"
+        private const val LOG_CHUNK_SIZE = 3000
+        private const val REPEAT_EXPAND_TAG = "RepeatExpand"
+    }
 
     // 1. 로컬 데이터 Flow (RRULE 전개 로직 적용)
     override val allSchedules: Flow<List<Schedule>> = scheduleDao.getAllSchedules()
@@ -432,8 +447,12 @@ class ScheduleRepositoryImpl @Inject constructor(
         } else {
             // --- [CASE 2] 경로 일정: 서버 API 호출 ---
             val token = accessToken ?: ""
-            val response =
-                api.createSchedule(token, request.copy(calendarId = calendarId?.toString()))
+            val routeRequest = request.toCreateRouteScheduleRequest(calendarId)
+            logRequestForSwagger("POST /api/v1/schedules", routeRequest)
+            val response = api.createRouteSchedule(
+                token,
+                routeRequest
+            )
 
             if (response.isSuccess && response.result != null) {
                 val serverResult = response.result
@@ -552,6 +571,87 @@ class ScheduleRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    private fun CreateScheduleRequest.toCreateRouteScheduleRequest(
+        calendarId: Long?
+    ): CreateRouteScheduleRequest {
+        return CreateRouteScheduleRequest(
+            title = title,
+            startDate = startDate,
+            endDate = endDate,
+            startTime = startTime,
+            endTime = endTime,
+            calendarId = calendarId?.toString() ?: this.calendarId,
+            color = color,
+            memo = memo,
+            isPathIncluded = isPathIncluded,
+            place = place,
+            reminders = reminders,
+            route = requireNotNull(route) { "Route schedule request requires route" }.normalizeRouteTimesForApi()
+        )
+    }
+
+    private fun RouteRequest.normalizeRouteTimesForApi(): RouteRequest {
+        return copy(
+            arrivalTime = arrivalTime.toUtcIsoString(),
+            departureTime = departureTime.toUtcIsoString(),
+            routeDetails = routeDetails.map { detail ->
+                detail.copy(
+                    transitDetail = detail.transitDetail?.copy(
+                        departureTime = detail.transitDetail.departureTime.toUtcIsoString(),
+                        arrivalTime = detail.transitDetail.arrivalTime.toUtcIsoString()
+                    )
+                )
+            }
+        )
+    }
+
+    private fun UpdateScheduleEditRouteRequest.normalizeRouteTimesForApi(): UpdateScheduleEditRouteRequest {
+        return copy(
+            arrivalTime = arrivalTime.toUtcIsoString(),
+            departureTime = departureTime.toUtcIsoString(),
+            routeDetails = routeDetails.map { detail ->
+                detail.copy(
+                    transitDetail = detail.transitDetail?.copy(
+                        departureTime = detail.transitDetail.departureTime.toUtcIsoString(),
+                        arrivalTime = detail.transitDetail.arrivalTime.toUtcIsoString()
+                    )
+                )
+            }
+        )
+    }
+
+    private fun String?.toUtcIsoString(): String? {
+        if (this.isNullOrBlank()) return this
+        return try {
+            if (endsWith("Z")) {
+                OffsetDateTime.parse(this)
+                    .withOffsetSameInstant(ZoneOffset.UTC)
+                    .format(UTC_API_TIME_FORMATTER)
+            } else {
+                LocalDateTime.parse(this)
+                    .atZone(ROUTE_SOURCE_ZONE)
+                    .withZoneSameInstant(ZoneOffset.UTC)
+                    .format(UTC_API_TIME_FORMATTER)
+            }
+        } catch (_: DateTimeParseException) {
+            this
+        }
+    }
+
+    private fun logRequestForSwagger(endpoint: String, body: Any) {
+        val prettyJson = GsonBuilder()
+            .serializeNulls()
+            .setPrettyPrinting()
+            .create()
+            .toJson(body)
+
+        Log.d(SWAGGER_LOG_TAG, endpoint)
+        prettyJson.chunked(LOG_CHUNK_SIZE).forEachIndexed { index, chunk ->
+            Log.d(SWAGGER_LOG_TAG, "chunk=${index + 1}\n$chunk")
+        }
+    }
+
     override fun getCalendarName(calendarId: Long): String? {
         val projection = arrayOf(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME)
         val uri = CalendarContract.Calendars.CONTENT_URI
@@ -611,8 +711,13 @@ class ScheduleRepositoryImpl @Inject constructor(
             // 1. 반복 일정 처리
             if (!schedule.repeatRule.isNullOrBlank()) {
                 val dtStartString = "${schedule.startDate} 00:00"
-                val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+                val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).apply {
+                    if (schedule.isAllDay) {
+                        timeZone = TimeZone.getTimeZone("UTC")
+                    }
+                }
                 val dtStartDate = try { sdf.parse(dtStartString) } catch (e: Exception) { null }
+                val spanDays = ChronoUnit.DAYS.between(startLocalDate, endLocalDate).coerceAtLeast(0)
 
                 if (dtStartDate != null) {
                     try {
@@ -680,15 +785,28 @@ class ScheduleRepositoryImpl @Inject constructor(
                         }
 
                         // 전개 시작
-                        val iterator = event.getDateIterator(TimeZone.getDefault())
+                        val iterator = event.getDateIterator(
+                            if (schedule.isAllDay) TimeZone.getTimeZone("UTC") else TimeZone.getDefault()
+                        )
                         iterator.advanceTo(rangeStartDate)
                         var count = 0
                         while (iterator.hasNext() && count < 1000) {
                             val occurrenceDate = iterator.next()
                             if (occurrenceDate.after(rangeEndDate)) break
 
-                            val oZDT = occurrenceDate.toInstant().atZone(ZoneId.systemDefault())
-                            val formattedDate = oZDT.toLocalDate().format(dateFormatter)
+                            val occurrenceLocalDate = if (schedule.isAllDay) {
+                                occurrenceDate.toInstant().atZone(ZoneOffset.UTC).toLocalDate()
+                            } else {
+                                occurrenceDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
+                            }
+                            val occurrenceEndLocalDate = occurrenceLocalDate.plusDays(spanDays)
+                            val formattedDate = occurrenceLocalDate.format(dateFormatter)
+                            if (schedule.isAllDay) {
+                                Log.d(
+                                    REPEAT_EXPAND_TAG,
+                                    "반복 확장: id=${schedule.id}, title=${schedule.title}, 원본=${schedule.startDate}~${schedule.endDate}, occurrence=${formattedDate}~${occurrenceEndLocalDate.format(dateFormatter)}, rawInstant=${occurrenceDate.toInstant()}"
+                                )
+                            }
 
                             // 💡 [중요] ICal4j 라이브러리에 따라 addExceptionDates가 완벽히 필터링 못할 경우를 대비한 2중 체크
                             // cancellationMap에 해당 부모ID와 현재 날짜가 등록되어 있다면 건너뜁니다.
@@ -699,8 +817,9 @@ class ScheduleRepositoryImpl @Inject constructor(
 
                             expandedList.add(schedule.copy(
                                 startDate = formattedDate,
-                                endDate = formattedDate,
-                                startTime = schedule.startTime
+                                endDate = occurrenceEndLocalDate.format(dateFormatter),
+                                startTime = if (schedule.isAllDay) "00:00" else schedule.startTime,
+                                endTime = if (schedule.isAllDay) "23:59" else schedule.endTime
                             ))
                             count++
                         }
@@ -1160,7 +1279,7 @@ class ScheduleRepositoryImpl @Inject constructor(
             accessToken = accessToken,
             scheduleId = scheduleId,
             scope = "SINGLE",
-            request = finalRequest
+            request = finalRequest.toCreateRouteScheduleRequest(calendarId)
         )
 
         // 3. 성공 시 로컬 DB 업데이트 로직 (기존 구현 유지)
@@ -1212,7 +1331,11 @@ class ScheduleRepositoryImpl @Inject constructor(
             Log.d("UpdateFlow", "2단계 - 기본 정보 수정 성공")
 
             // 3단계: 새로운 경로 등록 (PUT)
-            val putRes = api.updateScheduleEditRoute(accessToken, scheduleId, routeRequest)
+            val putRes = api.updateScheduleEditRoute(
+                accessToken,
+                scheduleId,
+                routeRequest.normalizeRouteTimesForApi()
+            )
 
             if (putRes.isSuccess) {
                 Log.d("UpdateFlow", "3단계 - 경로 등록 성공")

--- a/app/src/main/java/com/example/pace/data/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/example/pace/data/viewmodel/ScheduleViewModel.kt
@@ -596,6 +596,14 @@ class ScheduleViewModel @Inject constructor(
         }
     }
 
+    fun getCalendarColorById(calendarId: Long): Int? {
+        return try {
+            repository.getCalendarColor(calendarId)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     fun deleteSchedule(id: Long, withRoute: Boolean) {
         viewModelScope.launch {
             if (withRoute) {

--- a/app/src/main/java/com/example/pace/data/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/example/pace/data/viewmodel/ScheduleViewModel.kt
@@ -231,9 +231,21 @@ class ScheduleViewModel @Inject constructor(
         schedules.filter { schedule ->
             // 💡 백엔드(ROUTE) 일정은 무조건 노출 || 일반 일정은 선택된 캘린더일 때만 노출
             schedule.type == "ROUTE" || selectedIds.isEmpty() || selectedIds.contains(schedule.calendarId)
-        }.groupBy { schedule ->
-            LocalDate.parse(schedule.startDate, dateFormatter)
-        }
+        }.flatMap { schedule ->
+            val startDate = runCatching { LocalDate.parse(schedule.startDate, dateFormatter) }.getOrNull()
+                ?: return@flatMap emptyList()
+            val endDate = runCatching { LocalDate.parse(schedule.endDate, dateFormatter) }.getOrNull()
+                ?: startDate
+
+            generateSequence(startDate) { current ->
+                current.plusDays(1).takeIf { !it.isAfter(endDate) }
+            }.map { date ->
+                date to schedule
+            }.toList()
+        }.groupBy(
+            keySelector = { it.first },
+            valueTransform = { it.second }
+        )
     }.flowOn(Dispatchers.IO)
         .stateIn(
             scope = viewModelScope,

--- a/app/src/main/java/com/example/pace/ui/add_schedule/GerneralScheduleFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/GerneralScheduleFragment.kt
@@ -68,6 +68,7 @@ class GeneralScheduleFragment : Fragment() {
     private var currentSelectedAlarms: IntArray? = null
     private var currentSelectedCalendarId: Long? = null
     private var currentSelectedCalendarName: String? = null
+    private var currentSelectedCalendarColor: Int? = null
 
     private val dateFormatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
     val colorInt = android.graphics.Color.parseColor(selectedColorHex)
@@ -160,7 +161,7 @@ class GeneralScheduleFragment : Fragment() {
                         val calendarName = viewModel.getCalendarNameById(it.calendarId)
                         binding.tvCalendarStatus.text = calendarName
                         binding.tvCalendarStatus.setTextColor(Color.BLACK)
-                        // 필요 시 색상 점 초기화 로직 추가
+                        applyCalendarColor(it.calendarId)
                     }
                 }
             }
@@ -234,11 +235,7 @@ class GeneralScheduleFragment : Fragment() {
             }
 
             // 색상 String -> Int 변환
-            val selectedColorInt = try {
-                android.graphics.Color.parseColor(selectedColorHex)
-            } catch (e: Exception) {
-                android.graphics.Color.parseColor("#DC354B")
-            }
+            val saveColorInt = getSaveColorInt()
 
             if (isEditMode && scheduleIdForEdit != -1L) {
                 // A. 수정 모드
@@ -256,7 +253,7 @@ class GeneralScheduleFragment : Fragment() {
                             endTime = if (isAllDay) "23:59" else binding.tvEndTime.text.toString(),
                             isAllDay = isAllDay,
                             calendarId = currentSelectedCalendarId ?: existing.calendarId,
-                            eventColor = selectedColorInt,
+                            eventColor = saveColorInt,
                             placeJson = placeRequest?.let { com.google.gson.Gson().toJson(it) },
                             reminders = currentSelectedAlarms?.toList() ?: existing.reminders,
 
@@ -289,7 +286,7 @@ class GeneralScheduleFragment : Fragment() {
                     placeId = selectedPlaceId,
                     customAlarms = currentSelectedAlarms?.toList(),
                     calendarId = currentSelectedCalendarId,
-                    selectedColor = selectedColorInt,
+                    selectedColor = saveColorInt,
                     repeatInfo = currentRepeatInfo // 보정된 RepeatInfo 전달
                 )
             }
@@ -601,6 +598,7 @@ class GeneralScheduleFragment : Fragment() {
                 binding.tvCalendarStatus.setTextColor(Color.BLACK)
 
                 if (calendarColor != -1) {
+                    currentSelectedCalendarColor = calendarColor
                     binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(calendarColor)
                 }
             }
@@ -628,6 +626,8 @@ class GeneralScheduleFragment : Fragment() {
 
         val color = Color.parseColor(colorStr)
         binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(color)
+        // 수동 색상 선택 시 캘린더 색상 우선순위 해제
+        currentSelectedCalendarColor = null
 
         // 2. UI 처리
         binding.layoutColorSelector.visibility = View.GONE
@@ -1026,6 +1026,7 @@ class GeneralScheduleFragment : Fragment() {
                 val calendarName = viewModel.getCalendarNameById(settings.calendarId)
                 binding.tvCalendarStatus.text = calendarName
                 binding.tvCalendarStatus.setTextColor(ContextCompat.getColor(requireContext(), R.color.black))
+                applyCalendarColor(settings.calendarId)
             }
         }
     }
@@ -1036,6 +1037,18 @@ class GeneralScheduleFragment : Fragment() {
             val texts = alarms.map { minutesToText(it) } // minutesToText 함수를 여기도 복사하거나 유틸로 분리
             binding.tvRemindStatus.text = texts.joinToString(", ")
         }
+    }
+
+    private fun applyCalendarColor(calendarId: Long?) {
+        if (calendarId == null || calendarId == -1L) return
+        val color = viewModel.getCalendarColorById(calendarId) ?: return
+        if (color == 0) return
+        currentSelectedCalendarColor = color
+        binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(color)
+    }
+
+    private fun getSaveColorInt(): Int {
+        return currentSelectedCalendarColor ?: Color.parseColor(selectedColorHex)
     }
     private fun minutesToText(minutes: Int): String {
         return when (minutes) {
@@ -1081,6 +1094,8 @@ class GeneralScheduleFragment : Fragment() {
                 // 1. 이름 및 메모
                 binding.etScheduleName.setText(s.title)
                 binding.etMemo.setText(s.memo)
+                binding.etScheduleName.setTextColor(Color.BLACK)
+                binding.etMemo.setTextColor(Color.BLACK)
 
                 // 3. 날짜 (안전한 파싱)
                 try {
@@ -1109,6 +1124,8 @@ class GeneralScheduleFragment : Fragment() {
                 // 시간 텍스트 직접 할당
                 binding.tvStartTime.text = if (isAllDay) "오전 00:00" else s.startTime
                 binding.tvEndTime.text = if (isAllDay) "오후 11:59" else s.endTime
+                binding.tvStartTime.setTextColor(Color.BLACK)
+                binding.tvEndTime.setTextColor(Color.BLACK)
                 updateTimeVisibility()
 
                 // 4. 반복 필드(repeatRule) 파싱 (RRULE -> RepeatInfo)
@@ -1135,11 +1152,16 @@ class GeneralScheduleFragment : Fragment() {
                         selectedLat = placeRequest.targetLat
                         selectedLng = placeRequest.targetLng
 
-                        binding.tvLocationStatus.text = selectedPlaceName
+                        binding.tvLocationStatus.text = if (!selectedPlaceName.isNullOrBlank()) {
+                            selectedPlaceName
+                        } else {
+                            s.location ?: "장소 정보 없음"
+                        }
                         binding.tvLocationStatus.setTextColor(Color.BLACK)
                     } catch (e: Exception) {
                         // 파싱 실패 시 일반 텍스트로라도 보여줌
                         binding.tvLocationStatus.text = s.location ?: "장소 정보 없음"
+                        binding.tvLocationStatus.setTextColor(Color.BLACK)
                     }
                 } else if (!s.location.isNullOrEmpty()) {
                     // 구글 캘린더 등 외부에서 온 일반 장소 텍스트만 있는 경우
@@ -1153,20 +1175,36 @@ class GeneralScheduleFragment : Fragment() {
                 }
 
                 // 6. 색상 및 알람
-                s.eventColor?.let { colorInt ->
-                    val hexColor = String.format("#%06X", (0xFFFFFF and colorInt))
-                    changeSelectedColor(hexColor)
-                    selectedColorHex = hexColor
+                val effectiveColor = when {
+                    s.eventColor != null && s.eventColor != 0 -> s.eventColor
+                    s.calendarColor != null && s.calendarColor != 0 -> s.calendarColor
+                    else -> null
+                }
+                if (effectiveColor != null) {
+                    val hexColor = String.format("#%06X", (0xFFFFFF and effectiveColor))
+                    if (s.eventColor != null && s.eventColor != 0) {
+                        changeSelectedColor(hexColor)
+                        selectedColorHex = hexColor
+                    } else {
+                        currentSelectedCalendarColor = effectiveColor
+                        binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(effectiveColor)
+                    }
+                } else {
+                    applyCalendarColor(s.calendarId)
                 }
                 if (s.reminders.isNotEmpty()) {
                     currentSelectedAlarms = s.reminders.toIntArray()
                     updateAlarmText(currentSelectedAlarms!!)
+                    binding.tvRemindStatus.setTextColor(Color.BLACK)
                 }
 
                 // 7. 캘린더 정보
                 currentSelectedCalendarId = s.calendarId
                 binding.tvCalendarStatus.text = viewModel.getCalendarNameById(s.calendarId)
                 binding.tvCalendarStatus.setTextColor(Color.BLACK)
+                if (s.eventColor == null || s.eventColor == 0) {
+                    applyCalendarColor(s.calendarId)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
@@ -67,8 +67,12 @@ import kotlin.compareTo
 @AndroidEntryPoint
 class RouteScheduleFragment : Fragment() {
 
+    // 바인딩
     private var _binding: FragmentRouteScheduleBinding? = null
     private val binding get() = _binding!!
+
+    // ViewModel
+    private val viewModel: ScheduleViewModel by viewModels()
 
     // 수정 모드 관련 변수
     private var isEditMode = false
@@ -76,8 +80,6 @@ class RouteScheduleFragment : Fragment() {
 
     // 경로 검색 -> 일정 추가 시 받는 ROUTE_DETAIL
     private var route: RouteResponse? = null
-
-    private var isEditingStartTime: Boolean = true
 
     // 경로탐색으로 전환될 때 같이 보낼 색깔(선택된 일정 색)
     private var selectedColor: String = "#DC354B"
@@ -97,24 +99,23 @@ class RouteScheduleFragment : Fragment() {
     private var lastDestLng: Double = Double.NaN
     private var lastRouteJson: String? = null
 
-
-    private val viewModel: ScheduleViewModel by viewModels()
-
+    // 날짜/시간
+    private var isEditingStartTime: Boolean = true
     private var startDate: LocalDate? = null
     private var endDate: LocalDate? = null
-
     private val dateFormatter = DateTimeFormatter.ofPattern("M월 d일 (E)", Locale.KOREAN)
 
+    // 색상/알림/캘린더
     private var selectedColorHex: String = "#53B332" // 기본 색상
 
     private var isFirstLoad = true // 최상단 멤버 변수로 추가
     private var currentSelectedAlarms: IntArray? = null
+    private var currentSelectedStartAlarms: IntArray? = null
     private var currentSelectedCalendarId: Long? = null
     private var currentSelectedCalendarName: String? = null
+    private var currentSelectedCalendarColor: Int? = null
 
-    private var currentSelectedStartAlarms: IntArray? = null
-
-
+    // 런처/콜백
     private val routeSearchLauncher = registerForActivityResult(
         androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult()
     ) { result ->
@@ -144,9 +145,9 @@ class RouteScheduleFragment : Fragment() {
         }
     }
 
-    val backPressedCallback = object: OnBackPressedCallback(true){
+    private val backPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            val dialog = AddCancelDialog(requireContext()){
+            val dialog = AddCancelDialog(requireContext()) {
                 if (parentFragmentManager.backStackEntryCount > 0) {
                     parentFragmentManager.popBackStack()
                 } else {
@@ -156,6 +157,7 @@ class RouteScheduleFragment : Fragment() {
             dialog.show()
         }
     }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -238,28 +240,6 @@ class RouteScheduleFragment : Fragment() {
                 // 경로가 확실히 있으므로 삭제 버튼 활성화
                 binding.deleteRouteIv.visibility = View.VISIBLE
                 binding.deleteRouteIv.bringToFront() // ⭐ 다른 뷰들보다 위로 올리기
-                binding.deleteRouteIv.setOnClickListener {
-                    Log.d("ROUTE_DELETE", "삭제 버튼 클릭")
-                    val dialog = DeleteRouteDialog(requireContext()) {
-                        // 1. 모든 관련 데이터 변수를 "진짜" 초기 상태로 리셋
-                        this.route = null           // 경로 객체
-                        this.lastRouteJson = null   // JSON 문자열
-
-                        // 출발지 정보 초기화
-                        this.lastStartName = null
-                        this.lastStartLat = Double.NaN
-                        this.lastStartLng = Double.NaN
-
-                        // 도착지 정보 초기화
-                        this.lastDestName = null
-                        this.lastDestLat = Double.NaN
-                        this.lastDestLng = Double.NaN
-
-                        // 2. UI를 초기 상태로 되돌리기 (null을 넘기면 내부의 removeAllViews()가 작동함)
-                        updateRouteInfo("", "", null)
-                    }
-                    dialog.show()
-                }
             } catch (e: Exception) {
                 // 만약 JSON 형식이 잘못되었다면 safe하게 처리
                 Log.e("RouteError", "JSON 파싱 실패: ${e.message}")
@@ -286,6 +266,7 @@ class RouteScheduleFragment : Fragment() {
 
 
 
+        //일정 알람 화면으로 갔다가 올 때 데이터 받는 부분
         parentFragmentManager.setFragmentResultListener("ROUTE_ALARM_KEY", viewLifecycleOwner) { _, bundle ->
             // 경로 일정 로직 수행
             val resultText = bundle.getString("selectedAlarm")
@@ -298,31 +279,27 @@ class RouteScheduleFragment : Fragment() {
                 // UI 업데이트 (ID: tvAlarmStatus 확인)
                 binding.tvAlarmStatus.text = resultText
                 binding.tvAlarmStatus.setTextColor(Color.BLACK)
-
             }
         }
 
-        // 2. 출발 알림 결과 받기
 
+        // 출발 알림 결과 받기
         parentFragmentManager.setFragmentResultListener("startAlarmKey", viewLifecycleOwner) { _, bundle ->
             val resultText = bundle.getString("selectedAlarm") ?: "출발 알림 안함"
             val resultMinutes = bundle.getIntArray("selectedAlarmMinutes")
 
             if (resultMinutes != null) {
-                currentSelectedStartAlarms = resultMinutes // 여기서 전역 변수 업데이트!
+                currentSelectedStartAlarms = resultMinutes
                 binding.tvStartalarmStatus.text = resultText
                 binding.tvStartalarmStatus.setTextColor(Color.BLACK)
-                Log.d("ROUTE_RECEIVE", "데이터 저장 완료: ${resultMinutes.contentToString()}")
             }
         }
 
-        // "calendarSelectKey" 대신 "ROUTE_CALENDAR_KEY" 사용
+        // 캘린더 선택 결과 받기
         parentFragmentManager.setFragmentResultListener("ROUTE_CALENDAR_KEY", viewLifecycleOwner) { _, bundle ->
             val selectedId = bundle.getLong("calendarId", -1L)
             val selectedName = bundle.getString("calendarName") ?: "내 일정"
             val calendarColor = bundle.getInt("selectedCalendarColor", -1)
-
-            android.util.Log.d("CALENDAR_RECEIVE", "경로 일정 수신: $selectedName")
 
             if (selectedId != -1L) {
                 currentSelectedCalendarId = selectedId
@@ -332,6 +309,7 @@ class RouteScheduleFragment : Fragment() {
                 binding.tvCalendarStatus.setTextColor(Color.BLACK)
 
                 if (calendarColor != -1) {
+                    currentSelectedCalendarColor = calendarColor
                     binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(calendarColor)
                 }
             }
@@ -463,6 +441,8 @@ class RouteScheduleFragment : Fragment() {
             val finalEndDate = endDate ?: finalStartDate
             val startTime = binding.tvStartTime.text.toString()
             val endTime = binding.tvEndTime.text.toString()
+            val saveColorInt = getSaveColorInt()
+            val saveColorHex = colorIntToHex(saveColorInt)
 
             // [디버깅] 현재 모드와 ID 확인 - 로그캣에서 "ConfirmMode"를 검색하세요.
             Log.d("ConfirmMode", "isEditMode: $isEditMode, scheduleId: $scheduleId, selectedColor: $selectedColorHex, calendarId: $currentSelectedCalendarId")
@@ -555,7 +535,7 @@ class RouteScheduleFragment : Fragment() {
                         startTime = startTime,
                         endTime = endTime,
                         calendarId = currentSelectedCalendarId?.toString(), // 💡 캘린더 반영
-                        color = selectedColorHex,                           // 💡 색상 String 반영
+                        color = saveColorHex,                               // 💡 선택한 캘린더 색상 반영
                         isPathIncluded = true,
                         repeatInfo = null,
                         place = PlaceRequest(lastDestName ?: "", lastDestLat, lastDestLng),
@@ -597,13 +577,12 @@ class RouteScheduleFragment : Fragment() {
                         place = PlaceRequest(lastDestName ?: "", lastDestLat, lastDestLng),
                         reminders = reminders,
                         route = routeObj,
-                        color = selectedColorHex, // 💡 선택한 색상 반영
+                        color = saveColorHex, // 💡 선택한 캘린더 색상 반영
                         calendarId = currentSelectedCalendarId?.toString() // 💡 서버 명세에 맞춰 String으로 추가
                     )
-                    val selectedColorInt = Color.parseColor(selectedColor)
                     // ViewModel의 createSchedule 호출
                     Log.d("ConfirmMode", "..., calendarId: $currentSelectedCalendarId")
-                    viewModel.createSchedule(createRequest, null, currentSelectedCalendarId, selectedColorInt)
+                    viewModel.createSchedule(createRequest, null, currentSelectedCalendarId, saveColorInt)
                 }
 
                 // 서버 응답 여부와 관계없이 로컬 알람 예약 로직 즉시 실행
@@ -1052,6 +1031,8 @@ class RouteScheduleFragment : Fragment() {
 
         val color = Color.parseColor(colorStr)
         binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(color)
+        // 수동 색상 선택 시 캘린더 색상 우선순위 해제
+        currentSelectedCalendarColor = null
 
         // 2. UI 처리
         binding.layoutColorSelector.visibility = View.GONE
@@ -1368,6 +1349,7 @@ class RouteScheduleFragment : Fragment() {
                 currentSelectedCalendarId = settings.calendarId
                 val calendarName = viewModel.getCalendarNameById(settings.calendarId)
                 binding.tvCalendarStatus.text = calendarName
+                applyCalendarColor(settings.calendarId)
             }
         }
     }
@@ -1505,6 +1487,22 @@ class RouteScheduleFragment : Fragment() {
         binding.tvStartalarmStatus.setTextColor(Color.BLACK) // 선택되면 검정색으로 변경
     }
 
+    private fun applyCalendarColor(calendarId: Long?) {
+        if (calendarId == null || calendarId == -1L) return
+        val color = viewModel.getCalendarColorById(calendarId) ?: return
+        if (color == 0) return
+        currentSelectedCalendarColor = color
+        binding.viewColorDot.backgroundTintList = ColorStateList.valueOf(color)
+    }
+
+    private fun getSaveColorInt(): Int {
+        return currentSelectedCalendarColor ?: Color.parseColor(selectedColorHex)
+    }
+
+    private fun colorIntToHex(color: Int): String {
+        return String.format("#%06X", 0xFFFFFF and color)
+    }
+
 
     // [함수 추가] 기존 데이터 로드 및 UI 세팅
     private fun setupEditMode(id: Long) {
@@ -1537,6 +1535,7 @@ class RouteScheduleFragment : Fragment() {
                         }
                         binding.tvCalendarStatus.text = calendarName ?: "내 일정"
                         binding.tvCalendarStatus.setTextColor(Color.BLACK)
+                        applyCalendarColor(currentSelectedCalendarId)
 
                         // (2) 날짜 및 시간 정보
                         startDate = LocalDate.parse(detail.scheduleInfo.startDate)
@@ -1610,7 +1609,7 @@ class RouteScheduleFragment : Fragment() {
             placeId = null,
             customAlarms = currentSelectedAlarms?.toList(),
             calendarId = currentSelectedCalendarId,
-            selectedColor = Color.parseColor(selectedColorHex),
+            selectedColor = getSaveColorInt(),
             repeatInfo = null // 보정된 RepeatInfo 전달
         )
     }

--- a/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
@@ -151,7 +151,6 @@ class RouteScheduleFragment : Fragment() {
                 if (parentFragmentManager.backStackEntryCount > 0) {
                     parentFragmentManager.popBackStack()
                 } else {
-                    requireActivity().finish()
                 }
             }
             dialog.show()
@@ -454,7 +453,6 @@ class RouteScheduleFragment : Fragment() {
                         viewModel.deleteSchedule(scheduleId, true)
                     }
                     saveAsNormalSchedule()
-                    requireActivity().finish()
                 }
                 dialog.show()
             }else{
@@ -586,7 +584,6 @@ class RouteScheduleFragment : Fragment() {
                 }
 
                 // 서버 응답 여부와 관계없이 로컬 알람 예약 로직 즉시 실행
-                scheduleSavedAlarms()
             }
         }
 

--- a/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
@@ -68,7 +68,7 @@ class CalendarPageFragment: Fragment() {
     // 캘린더에 표시할 데이터를 담을 Map (날짜 -> 일정 리스트)
     private var events = mapOf<LocalDate, List<Schedule>>()
     private var allSchedules:List<Schedule> = emptyList()
-    private var rowMap = mutableMapOf<Long, Int>()
+    private var rowAssignmentCache = mutableMapOf<String, Int>()
 
     private var selectedMonth: YearMonth = YearMonth.now()
     private var selectedDate: LocalDate? = null
@@ -127,6 +127,10 @@ class CalendarPageFragment: Fragment() {
                 // 현재 달의 날짜(MonthDate)일 때만 활성화 하기
                 val isCurrentMonth = day.position == DayPosition.MonthDate
                 updateDayUI(container.textView, container.rootLayout, day.date, isCurrentMonth)
+                if (!isCurrentMonth && bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {
+                    container.eventContainer.removeAllViews()
+                    return
+                }
                 // 바텀 시트 여부에 따라 다른 UI 적용
                 when(bottomSheetBehavior.state){
                     BottomSheetBehavior.STATE_HIDDEN -> {
@@ -180,7 +184,6 @@ class CalendarPageFragment: Fragment() {
 
         // 주간 캘린더 스크롤 리스너
         binding.weekCalendarView.weekScrollListener = { week ->
-
             val weekFirstDate = week.days.first().date
             selectedMonth = YearMonth.from(weekFirstDate)
             updateTitle()
@@ -288,6 +291,7 @@ class CalendarPageFragment: Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.scheduleMap.collectLatest { groupedMap ->
                 events = groupedMap
+                rowAssignmentCache.clear()
 
                 if (groupedMap.isNotEmpty()) {
                     groupedMap.values.flatten()
@@ -308,6 +312,7 @@ class CalendarPageFragment: Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.allSchedules.collectLatest { schedules ->
                 allSchedules = schedules
+                rowAssignmentCache.clear()
                 binding.calendarView.notifyCalendarChanged()
                 binding.weekCalendarView.notifyCalendarChanged()
             }
@@ -384,19 +389,25 @@ class CalendarPageFragment: Fragment() {
                             binding.calendarView.layoutParams.height = targetHeight
                             binding.calendarView.requestLayout()
                         }
+                        notifyVisibleCalendarDates()
                     }
                     BottomSheetBehavior.STATE_EXPANDED -> {
-                        crossfade(
-                            fadeInView = binding.weekCalendarView,
-                            fadeOutView = binding.calendarView
-                        )
-                        binding.weekCalendarView.scrollToWeek(selectedDate ?: today)
+                        binding.weekCalendarView.alpha = 0f
+                        binding.weekCalendarView.visibility = View.INVISIBLE
+                        binding.weekCalendarView.post {
+                            binding.weekCalendarView.scrollToWeek(selectedDate ?: today)
+                            notifyVisibleCalendarDates()
+                            binding.weekCalendarView.visibility = View.VISIBLE
+                            crossfade(
+                                fadeInView = binding.weekCalendarView,
+                                fadeOutView = binding.calendarView
+                            )
+                        }
                     }
                 }
             }
 
             override fun onSlide(bottomSheet: View, slideOffset: Float) {
-                // no-op
             }
         })
     }
@@ -473,7 +484,7 @@ class CalendarPageFragment: Fragment() {
         }
     }
 
-    private fun crossfade(fadeInView: View, fadeOutView: View, durationMs: Long = 200) {
+    private fun crossfade(fadeInView: View, fadeOutView: View, durationMs: Long = 350) {
         /*
          * 두 화면 요소를 부드럽게 바꿔치기 한다.
          * 하나는 천천히 나타나고, 다른 하나는 천천히 사라진다.
@@ -505,6 +516,23 @@ class CalendarPageFragment: Fragment() {
             fadeOutView.alpha = 0f
             fadeOutView.visibility = View.GONE
         }
+    }
+
+    private fun notifyVisibleCalendarDates() {
+        binding.calendarView.findFirstVisibleMonth()?.weekDays
+            ?.flatten()
+            ?.map { it.date }
+            ?.distinct()
+            ?.forEach { date ->
+                binding.calendarView.notifyDateChanged(date)
+            }
+
+        binding.weekCalendarView.findFirstVisibleWeek()?.days
+            ?.map { it.date }
+            ?.distinct()
+            ?.forEach { date ->
+                binding.weekCalendarView.notifyDateChanged(date)
+            }
     }
 
     // CalendarPageFragment.kt 의 selectDate 수정
@@ -550,14 +578,13 @@ class CalendarPageFragment: Fragment() {
                 if (!fromScroll) {
                     // 이 안에서 scrollToMonth 등이 호출될 때 리스너가 동작하지 않도록 보장
                     binding.calendarView.scrollToMonth(YearMonth.from(date))
-                    binding.weekCalendarView.scrollToWeek(date)
                 }
 
                 // 약간의 딜레이 뒤에 해제 (스크롤이 완전히 끝날 때까지 보호)
                 binding.root.postDelayed({ isProgrammaticScroll = false }, 100)
             }
 
-            if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {
+            if (!fromScroll && bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {
                 bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
             }
         }
@@ -691,15 +718,14 @@ class CalendarPageFragment: Fragment() {
         if(!events[date].isNullOrEmpty()){
             val sortedEvents = getSortedScheduleListOfDate(date)
             var row = 0
-            var index = 0
 
             if(sortedEvents.isNotEmpty()){
-                val n = setPageItemNumber(sortedEvents)
+                val maxVisibleRows = setPageItemNumber(sortedEvents)
                 for(schedule in sortedEvents) {
-                    val allDatesForThisSchedule = getAllDatesForThisSchedule(schedule)
+                    val allDatesForThisSchedule = getDisplayDatesForSchedule(schedule)
                     if(allDatesForThisSchedule.isNotEmpty()){
-                        // 상위 일정 3-4개만 표시
-                        if(row == 3 || index == n){
+                        val scheduleRow = getAssignedRow(schedule)
+                        if (scheduleRow >= maxVisibleRows) {
                             break
                         }
 
@@ -709,8 +735,19 @@ class CalendarPageFragment: Fragment() {
                         val isEnd = date.isEqual(lastDate)
                         val params = LinearLayout.LayoutParams(MATCH_PARENT, (16 * resources.displayMetrics.density).roundToInt())
 
+                        if (row < scheduleRow) {
+                            val spaceCount = scheduleRow - row
+                            repeat(spaceCount) {
+                                val binding = ItemMonthViewMultipleDaysBinding.inflate(layoutInflater, eventContainer, false)
+                                binding.root.visibility = View.INVISIBLE
+                                binding.root.layoutParams = params
+                                eventContainer.addView(binding.root)
+                            }
+                            row = scheduleRow
+                        }
+
                         // 하루 일정 or 반복 일정
-                        if(firstDate == lastDate || !schedule.repeatRule.isNullOrEmpty()){
+                        if(firstDate == lastDate){
                             val binding = ItemMonthViewSingleDayBinding.inflate(layoutInflater)
                             val icon = binding.itemMonthViewSingleColor
                             icon.backgroundTintList = setBackgroundTintByScheduleColor(schedule)
@@ -720,23 +757,6 @@ class CalendarPageFragment: Fragment() {
                         }
                         // 장기 일정
                         else{
-                            // 장기 일정 시작일 때 현재 위치 기록
-                            if(isStart){
-                                rowMap[schedule.id] = row
-                            }
-                            // 이미 장기 일정이 작성됐다면 해당 줄 전까지 빈 뷰 작성
-                            val scheduleRow = rowMap[schedule.id]
-                            if (!isStart && scheduleRow != null && row < scheduleRow){
-                                val spaceCount = scheduleRow - row
-                                for(i in 1..spaceCount){
-                                    val binding = ItemMonthViewMultipleDaysBinding.inflate(layoutInflater, eventContainer,false)
-                                    binding.itemMonthViewMultipleDays.text = "test"
-                                    binding.root.visibility = View.INVISIBLE
-                                    binding.root.layoutParams = params
-                                    eventContainer.addView(binding.root)
-                                }
-                                row = scheduleRow
-                            }
                             // 장기 일정 바인딩
                             val binding = ItemMonthViewMultipleDaysBinding.inflate(layoutInflater)
                             binding.itemMonthViewMultipleDays.backgroundTintList = setBackgroundTintByScheduleColor(schedule)
@@ -750,24 +770,17 @@ class CalendarPageFragment: Fragment() {
                                 else -> ""
                             }
 
-                            // 장기 일정 마지막 날이라면, 위치 제거
-                            if(isEnd){
-                                rowMap.remove(schedule.id)
-                            }
-
                             binding.root.layoutParams = params
                             eventContainer.addView(binding.root)
                         }
                     }
                     row++
-                    index++
-
                 }
-                // 총 일정이 4개 초과거나 장기 일정으로 3칸을 모두 차지했을 경우, 남은 개수 표시
-                if(n == 3 || row == 3){
+                val hiddenCount = sortedEvents.count { getAssignedRow(it) >= maxVisibleRows }
+                if(maxVisibleRows == 3 && hiddenCount > 0){
                     val binding = ItemMonthViewMultipleDaysBinding.inflate(layoutInflater)
                     binding.itemMonthViewMultipleDays.backgroundTintList = ColorStateList.valueOf(resources.getColor(R.color.transparent))
-                    binding.itemMonthViewMultipleDays.text = if(n == 3) "+${sortedEvents.size - 3}" else if(sortedEvents.size - index > 0)"+${sortedEvents.size - index}" else ""
+                    binding.itemMonthViewMultipleDays.text = "+$hiddenCount"
                     eventContainer.addView(binding.root)
                 }
             }
@@ -782,15 +795,14 @@ class CalendarPageFragment: Fragment() {
         if(!events[date].isNullOrEmpty()){
             val sortedEvents = getSortedScheduleListOfDate(date)
             var row = 0
-            var index = 0
 
             if(sortedEvents.isNotEmpty()){
-                val n = setPageItemNumber(sortedEvents)
+                val maxVisibleRows = setPageItemNumber(sortedEvents)
                 for(schedule in sortedEvents) {
-                    val allDatesForThisSchedule = getAllDatesForThisSchedule(schedule)
+                    val allDatesForThisSchedule = getDisplayDatesForSchedule(schedule)
                     if(allDatesForThisSchedule.isNotEmpty()){
-                        // 상위 일정 3-4개만 표시
-                        if(row == 3 || index == n){
+                        val scheduleRow = getAssignedRow(schedule)
+                        if (scheduleRow >= maxVisibleRows) {
                             break
                         }
 
@@ -800,8 +812,19 @@ class CalendarPageFragment: Fragment() {
                         val isEnd = date.isEqual(lastDate)
                         val params = LinearLayout.LayoutParams(MATCH_PARENT, (8 * resources.displayMetrics.density).roundToInt())
 
+                        if (row < scheduleRow) {
+                            val spaceCount = scheduleRow - row
+                            repeat(spaceCount) {
+                                val binding = ItemWeekViewBinding.inflate(layoutInflater, eventContainer, false)
+                                binding.itemWeekTv.visibility = View.INVISIBLE
+                                binding.itemWeekTv.layoutParams = params
+                                eventContainer.addView(binding.root)
+                            }
+                            row = scheduleRow
+                        }
+
                         // 하루 일정 or 반복 일정
-                        if(firstDate == lastDate || !schedule.repeatRule.isNullOrEmpty()){
+                        if(firstDate == lastDate){
                             val binding = ItemWeekViewBinding.inflate(layoutInflater)
                             binding.itemWeekTv.backgroundTintList = setBackgroundTintByScheduleColor(schedule)
                             binding.itemWeekTv.layoutParams = params
@@ -809,24 +832,6 @@ class CalendarPageFragment: Fragment() {
                         }
                         // 장기 일정
                         else{
-                            // 장기 일정 시작일 때 현재 위치 기록
-                            if(isStart){
-                                rowMap[schedule.id] = row
-                            }
-
-                            // 이미 장기 일정이 작성됐다면 해당 줄 전까지 빈 뷰 작성
-                            val scheduleRow = rowMap[schedule.id]
-                            if (!isStart && scheduleRow != null && row < scheduleRow){
-                                val spaceCount = scheduleRow - row
-                                for(i in 1..spaceCount){
-                                    val binding = ItemWeekViewBinding.inflate(layoutInflater, eventContainer,false)
-                                    binding.itemWeekTv.visibility = View.INVISIBLE
-                                    binding.itemWeekTv.layoutParams = params
-                                    eventContainer.addView(binding.root)
-                                }
-                                row = scheduleRow
-                            }
-
                             // 장기 일정 바인딩
                             val binding = ItemWeekViewBinding.inflate(layoutInflater)
                             binding.itemWeekTv.backgroundTintList = setBackgroundTintByScheduleColor(schedule)
@@ -836,17 +841,11 @@ class CalendarPageFragment: Fragment() {
                                 else -> R.drawable.bg_item_week_view_middle
                             })
 
-                            // 장기 일정 마지막 날이라면, 위치 제거
-                            if(isEnd){
-                                rowMap.remove(schedule.id)
-                            }
-
                             binding.itemWeekTv.layoutParams = params
                             eventContainer.addView(binding.root)
                         }
                     }
                     row++
-                    index++
                 }
             }
         }
@@ -855,17 +854,132 @@ class CalendarPageFragment: Fragment() {
     // date의 일정을 장기 -> 하루 일정 순으로 정렬
     private fun getSortedScheduleListOfDate(date: LocalDate): List<Schedule>{
         return events[date]?.sortedWith(compareBy<Schedule> { schedule ->
-            val allDates = allSchedules.filter {
-                it.id == schedule.id
-            }.map {
-                it.startDate
-            }.distinct()
-            if (allDates.size > 1 && schedule.repeatRule.isNullOrEmpty()) -1 else 0
+            getAssignedRow(schedule)
+        }.thenBy { schedule ->
+            val allDates = getDisplayDatesForSchedule(schedule)
+            if (allDates.size > 1) 0 else 1
+        }.thenBy { schedule ->
+            if (schedule.isAllDay) 0 else 1
+        }.thenBy { schedule ->
+            schedule.startTime
+        }.thenBy { schedule ->
+            schedule.title.orEmpty()
+        }.thenBy { schedule ->
+            schedule.startDate
+        }.thenBy { schedule ->
+            schedule.id
         }) ?: emptyList()
     }
 
     // 해당 일정이 속한 모든 날짜 가져오기
     private fun getAllDatesForThisSchedule(schedule: Schedule): List<String> = allSchedules.filter { it.id == schedule.id }.map{ it.startDate }.distinct().sorted()
+
+    private fun getDisplayDatesForSchedule(schedule: Schedule): List<String> {
+        return if (!schedule.repeatRule.isNullOrEmpty()) {
+            val start = runCatching { LocalDate.parse(schedule.startDate) }.getOrNull() ?: return listOf(schedule.startDate)
+            val end = runCatching { LocalDate.parse(schedule.endDate) }.getOrNull() ?: return listOf(schedule.startDate)
+            generateSequence(start) { current ->
+                current.plusDays(1).takeIf { !it.isAfter(end) }
+            }.map { it.toString() }.toList()
+        } else {
+            getAllDatesForThisSchedule(schedule)
+        }
+    }
+
+    private fun getOccurrenceKey(schedule: Schedule): String {
+        return if (!schedule.repeatRule.isNullOrEmpty()) {
+            "${schedule.id}_${schedule.startDate}_${schedule.endDate}"
+        } else {
+            schedule.id.toString()
+        }
+    }
+
+    private fun getAssignedRow(schedule: Schedule): Int {
+        if (rowAssignmentCache.isEmpty()) {
+            rowAssignmentCache = buildRowAssignments().toMutableMap()
+        }
+        return rowAssignmentCache[getOccurrenceKey(schedule)] ?: 0
+    }
+
+    private fun buildRowAssignments(): Map<String, Int> {
+        data class DisplayOccurrence(
+            val key: String,
+            val start: LocalDate,
+            val end: LocalDate,
+            val priority: Int,
+            val title: String,
+            val id: Long
+        )
+
+        val occurrences = allSchedules
+            .groupBy { schedule -> getOccurrenceKey(schedule) }
+            .mapNotNull { (key, schedules) ->
+                val representative = schedules.firstOrNull() ?: return@mapNotNull null
+                val dates = getDisplayDatesForSchedule(representative)
+                    .mapNotNull { runCatching { LocalDate.parse(it) }.getOrNull() }
+                    .distinct()
+                    .sorted()
+
+                if (dates.isEmpty()) {
+                    null
+                } else {
+                    val isMultiDay = dates.size > 1
+                    val priority = when {
+                        isMultiDay && representative.isAllDay && !representative.repeatRule.isNullOrEmpty() -> 0
+                        isMultiDay && representative.isAllDay -> 1
+                        isMultiDay && !representative.repeatRule.isNullOrEmpty() -> 2
+                        isMultiDay -> 3
+                        representative.isAllDay && !representative.repeatRule.isNullOrEmpty() -> 4
+                        representative.isAllDay -> 5
+                        !representative.repeatRule.isNullOrEmpty() -> 6
+                        else -> 7
+                    }
+                    DisplayOccurrence(
+                        key = key,
+                        start = dates.first(),
+                        end = dates.last(),
+                        priority = priority,
+                        title = representative.title.orEmpty(),
+                        id = representative.id
+                    )
+                }
+            }
+            .sortedWith(
+                compareBy<DisplayOccurrence>({ it.priority }, { it.start }, { it.end }, { it.title }, { it.id })
+            )
+
+        val occupiedByDate = mutableMapOf<LocalDate, MutableSet<Int>>()
+        val assignments = mutableMapOf<String, Int>()
+
+        occurrences.forEach { occurrence ->
+            var row = 0
+            while (isRowOccupied(occurrence.start, occurrence.end, row, occupiedByDate)) {
+                row++
+            }
+            assignments[occurrence.key] = row
+
+            generateSequence(occurrence.start) { current ->
+                current.plusDays(1).takeIf { !it.isAfter(occurrence.end) }
+            }.forEach { date ->
+                occupiedByDate.getOrPut(date) { mutableSetOf() }.add(row)
+            }
+        }
+
+        return assignments
+    }
+
+    private fun isRowOccupied(
+        start: LocalDate,
+        end: LocalDate,
+        row: Int,
+        occupiedByDate: Map<LocalDate, Set<Int>>
+    ): Boolean {
+        return generateSequence(start) { current ->
+            current.plusDays(1).takeIf { !it.isAfter(end) }
+        }.any { date ->
+            occupiedByDate[date]?.contains(row) == true
+        }
+    }
 
     // 일정 색상에 따라 텍스트뷰 배경 적용
     private fun setBackgroundTintByScheduleColor(schedule: Schedule): ColorStateList{


### PR DESCRIPTION
- [FEAT]
# PR템플릿 

## 변경 사항 요약
- 백엔드 변경된 api기준으로 요청을 바꿈(백엔드 서버 오류로 개발 중단 저녁에 비니가 확인해준다고 함)
- 격자모양 캘린더에 아이템이 이쁘게 들어감(테트리스 하는 순서 정함 규칙은 노션에 진행상황으로 적겠음)
- 격자모양 캘린더에 여러가지 ui규칙을 설정함 너무 여러가지라 다 못적음

## 체크리스트
- [v] 코드 빌드 성공
- [v] 에뮬레이터 실행 시 성공

## 사진올리는곳
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/6ee65cd7-3bfb-4100-aec6-df57e2a45e99" />