### PR TITLE
[Refactor]: 루트 토큰 변경, 룸db2순위 반영, 폰트 몇개 수정

### DIFF
--- a/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
@@ -55,6 +55,10 @@ interface ScheduleRepository {
         startDate: String,
         endDate: String?
     ): RawDefaultResponse<List<RouteOnlyScheduleData?>>
+    suspend fun getLocalRouteSchedules(
+        startDate: String,
+        endDate: String
+    ): List<RouteOnlyScheduleData>
 
     suspend fun updateExDate(schedule: Schedule)
     suspend fun getScheduleById(id: Long): Schedule?

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
@@ -1049,6 +1049,44 @@ class ScheduleRepositoryImpl @Inject constructor(
         )
     }
 
+    override suspend fun getLocalRouteSchedules(
+        startDate: String,
+        endDate: String
+    ): List<RouteOnlyScheduleData> = withContext(Dispatchers.IO) {
+        scheduleDao.getServerRouteSchedulesInRange(startDate, endDate)
+            .mapNotNull { it.toLocalRouteOnlyScheduleData() }
+    }
+
+    private fun Schedule.toLocalRouteOnlyScheduleData(): RouteOnlyScheduleData? {
+        val routeInfo = routeJson
+            ?.takeIf { it.isNotBlank() }
+            ?.let { json ->
+                runCatching { Gson().fromJson(json, RouteInfo::class.java) }.getOrNull()
+            }
+            ?: return null
+
+        val colorHex = eventColor?.let { color ->
+            String.format(Locale.US, "#%06X", 0xFFFFFF and color)
+        }
+
+        return RouteOnlyScheduleData(
+            scheduleId = id,
+            scheduleInfo = ScheduleInfo(
+                title = title ?: "",
+                isAllDay = isAllDay,
+                startDate = startDate,
+                endDate = endDate,
+                startTime = startTime,
+                endTime = endTime,
+                memo = memo,
+                isPathIncluded = true,
+                color = colorHex,
+                calendarId = calendarId.toString()
+            ),
+            route = routeInfo
+        )
+    }
+
 
     // Delete a normal schedule from Calendar Provider and Room
     override suspend fun deleteNormalSchedule(id: Long): RawDefaultResponse<String> {

--- a/app/src/main/java/com/example/pace/data/viewmodel/GroupViewModel.kt
+++ b/app/src/main/java/com/example/pace/data/viewmodel/GroupViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.pace.BuildConfig
 import com.example.pace.data.datasource.AuthDataStore
 import com.example.pace.data.model.request.CreateGroupRequest
 import com.example.pace.data.model.request.DeletePlacesRequest
@@ -41,7 +40,15 @@ class GroupViewModel @Inject constructor(
     var currentSortType: String = "LATEST"
         private set
 
-    private val token: String = BuildConfig.BEARER_TOKEN
+    private val token: String
+        get() {
+            val accessToken = authDataStore.getAccessToken().orEmpty()
+            return if (accessToken.isNotEmpty() && !accessToken.startsWith("Bearer ")) {
+                "Bearer $accessToken"
+            } else {
+                accessToken
+            }
+        }
 
     private val _savedPlaces = MutableLiveData<List<SavePlaceResponse>>()
     val savedPlaces: LiveData<List<SavePlaceResponse>> get() = _savedPlaces

--- a/app/src/main/java/com/example/pace/data/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/example/pace/data/viewmodel/RouteViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.pace.BuildConfig
+import com.example.pace.data.datasource.AuthDataStore
 import com.example.pace.data.model.response.RouteResponse
 import com.example.pace.data.model.request.RouteSearchRequest
 import com.example.pace.data.model.response.RouteOnlyScheduleData
@@ -24,7 +24,8 @@ import javax.inject.Inject
 @HiltViewModel
 class RouteViewModel @Inject constructor(
     private val routeRepository: RouteRepository,
-    private val scheduleRepository: ScheduleRepository
+    private val scheduleRepository: ScheduleRepository,
+    private val authDataStore: AuthDataStore
 ) : ViewModel() {
     private val _routeResult = MutableLiveData<List<RouteResponse>>()
     val routeResult: LiveData<List<RouteResponse>> get() = _routeResult
@@ -43,7 +44,6 @@ class RouteViewModel @Inject constructor(
     private val _errorMessage = MutableLiveData<String>()
     val errorMessage: LiveData<String> get() = _errorMessage
 
-    val token = BuildConfig.BEARER_TOKEN
     fun searchRoutes(accessToken: String, request: RouteSearchRequest) {
         viewModelScope.launch {
             _isLoading.value = true
@@ -84,13 +84,19 @@ class RouteViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 // 오늘 날짜 구하기 (yyyy-MM-dd)
+                val token = authDataStore.getAccessToken() ?: ""
+                val fullToken = if (token.isNotEmpty() && !token.startsWith("Bearer ")) "Bearer $token" else token
+                if (fullToken.isEmpty()) {
+                    _routeOnlySchedule.value = null
+                    return@launch
+                }
                 val today = LocalDate.now().toString()
 
                 Log.d("RouteViewModel", "스케줄 조회 시작: $today")
 
                 // 리포지토리 호출 (RawDefaultResponse 반환됨)
                 val response = scheduleRepository.getScheduleListForRoute(
-                    accessToken = token,
+                    accessToken = fullToken,
                     startDate = today,
                     endDate = today
                 )
@@ -128,17 +134,31 @@ class RouteViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoading.value = true
             try {
+                val token = authDataStore.getAccessToken() ?: ""
+                val fullToken = if (token.isNotEmpty() && !token.startsWith("Bearer ")) "Bearer $token" else token
+                if (fullToken.isEmpty()) {
+                    _routeScheduleList.value = emptyList()
+                    return@launch
+                }
                 val today = LocalDate.now().toString()
 
                 // 새로 만든 리스트용 함수 호출 (endDate = null)
                 val response = scheduleRepository.getAllRouteSchedules(
-                    accessToken = token, // 뷰모델 직접 참조
+                    accessToken = fullToken, // 뷰모델 직접 참조
                     startDate = today,
                     endDate = null
                 )
 
                 if (response.isSuccess) {
-                    _routeScheduleList.value = response.result?.filterNotNull() ?: emptyList()
+                    val serverSchedules = response.result?.filterNotNull() ?: emptyList()
+                    _routeScheduleList.value = if (serverSchedules.isNotEmpty()) {
+                        serverSchedules
+                    } else {
+                        scheduleRepository.getLocalRouteSchedules(
+                            startDate = today,
+                            endDate = today
+                        )
+                    }
                 }
             } catch (e: Exception) {
                 Log.e("RouteViewModel", "전체 목록 로드 실패: ${e.message}")

--- a/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
@@ -591,7 +591,14 @@ class RouteFragment : Fragment() {
         Log.d("RouteApi", "Full Request: $request")
         Log.d("RouteApi", "=====================================================")
 
-        val token = BuildConfig.BEARER_TOKEN
+        val app = requireActivity().application as PaceApplication
+        val accessToken = app.authDataStore.getAccessToken().orEmpty()
+        val token = if (accessToken.isNotEmpty() && !accessToken.startsWith("Bearer ")) {
+            "Bearer $accessToken"
+        } else {
+            accessToken
+        }
+        if (token.isEmpty()) return
 
         routeViewModel.searchRoutes(token, request)
     }

--- a/app/src/main/res/layout/activity_add_schedule.xml
+++ b/app/src/main/res/layout/activity_add_schedule.xml
@@ -20,7 +20,7 @@
             android:layout_gravity="center"
             android:text="새로운 일정 추가"
             android:textAppearance="@style/TextAppearance.App.HeadlineSm"
-            android:textStyle="bold" />
+            android:fontFamily="@font/pretendard_semibold" />
     </androidx.appcompat.widget.Toolbar>
 
     <com.google.android.material.tabs.TabLayout


### PR DESCRIPTION
- [FEAT]
# PR템플릿 

## 변경 사항 요약
- GroupViewModel.kt, RouteViewModel.kt, 경로검색시 RouteFragment.kt의 개발자용 토큰 대신 authDataStore에서 액세스 토큰 사용
- 루트 뷰모델과 스케줄 레포지토리에 1순위 서버, 2순위 룸db, 3순위 대체 토스트메세지를 통하여 인터넷 미연결 시에도 경로일정 목록 확인 가능
- 폰트 디자인 한줄 변경함 add_schedule_activity에다가

## 체크리스트
- [v] 코드 빌드 성공
- [v] 에뮬레이터 실행 시 성공

## 사진올리는곳
