### PR TITLE
[Refactor]: 원스톤 qa 2번째

### DIFF
--- a/app/src/main/java/com/example/pace/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/pace/ui/main/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
+import androidx.fragment.app.Fragment
 import com.example.pace.R
 import com.example.pace.databinding.ActivityMainBinding
 import com.example.pace.ui.main.calendar.CalendarFragment
@@ -102,6 +103,12 @@ class MainActivity : AppCompatActivity() {
     private lateinit var spf: SharedPreferences
     private var currentBottomMenuItem = R.id.home
 
+    companion object {
+        private const val TAG_HOME = "main_home"
+        private const val TAG_CALENDAR = "main_calendar"
+        private const val TAG_ROUTE = "main_route"
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
@@ -138,7 +145,9 @@ class MainActivity : AppCompatActivity() {
 
         // 2. 초기 화면 설정 (Home)
         if (savedInstanceState == null) {
-            supportFragmentManager.beginTransaction().replace(R.id.main_fcv, HomeFragment()).commit()
+            supportFragmentManager.beginTransaction()
+                .add(R.id.main_fcv, HomeFragment(), TAG_HOME)
+                .commit()
             currentBottomMenuItem = R.id.home
         }
 
@@ -158,9 +167,7 @@ class MainActivity : AppCompatActivity() {
         binding.mainBnv.setOnItemSelectedListener { item ->
             changeFragment(item)
         }
-        binding.mainBnv.setOnItemReselectedListener { item ->
-            refreshFragment(item)
-        }
+        binding.mainBnv.setOnItemReselectedListener { }
 
         // 4. 설정 버튼 이동
         binding.mainSettingsIv.setOnClickListener {
@@ -247,12 +254,16 @@ class MainActivity : AppCompatActivity() {
     private fun changeFragment(item: MenuItem): Boolean {
         binding.searchEt.clearFocus()
 
+        if (item.itemId == currentBottomMenuItem) {
+            return true
+        }
+
         when (item.itemId) {
             R.id.home -> {
-                supportFragmentManager.beginTransaction().replace(
-                        R.id.main_fcv,
-                        HomeFragment()
-                    ).commit()
+                switchFragment(TAG_HOME) { HomeFragment() }
+                supportFragmentManager.executePendingTransactions()
+                (supportFragmentManager.findFragmentByTag(TAG_HOME) as? HomeFragment)?.resetToToday()
+                currentBottomMenuItem = R.id.home
                 binding.mainLogoIv.visibility = View.VISIBLE
                 binding.mainSettingsIv.visibility = View.VISIBLE
                 binding.scheduleTitleTv.visibility = View.GONE
@@ -266,10 +277,10 @@ class MainActivity : AppCompatActivity() {
             }
 
             R.id.calendar -> {
-                supportFragmentManager.beginTransaction().replace(
-                    R.id.main_fcv,
-                    CalendarFragment()
-                ).commit()
+                switchFragment(TAG_CALENDAR) { CalendarFragment() }
+                supportFragmentManager.executePendingTransactions()
+                (supportFragmentManager.findFragmentByTag(TAG_CALENDAR) as? CalendarFragment)?.resetToTodayState()
+                currentBottomMenuItem = R.id.calendar
                 binding.mainLogoIv.visibility = android.view.View.GONE
                 binding.mainSettingsIv.visibility = android.view.View.GONE
                 binding.scheduleActionContainer.visibility = View.VISIBLE
@@ -283,10 +294,10 @@ class MainActivity : AppCompatActivity() {
             }
 
             R.id.route -> {
-                supportFragmentManager.beginTransaction().replace(
-                    R.id.main_fcv,
-                    RouteFragment()
-                ).commit()
+                switchFragment(TAG_ROUTE) { RouteFragment() }
+                supportFragmentManager.executePendingTransactions()
+                (supportFragmentManager.findFragmentByTag(TAG_ROUTE) as? RouteFragment)?.resetToCurrentLocationState()
+                currentBottomMenuItem = R.id.route
                 binding.mainLogoIv.visibility = android.view.View.GONE
                 binding.mainSettingsIv.visibility = android.view.View.GONE
                 binding.scheduleTitleTv.visibility = android.view.View.GONE
@@ -302,33 +313,28 @@ class MainActivity : AppCompatActivity() {
         }
     }
     // 같은 프래그먼트 선택 시 새로고침
-    private fun refreshFragment(item: MenuItem): Boolean{
-        binding.searchEt.clearFocus()
-
-        when (item.itemId) {
-            R.id.home -> {
-                supportFragmentManager.beginTransaction().replace(R.id.main_fcv, HomeFragment()).commit()
-                spf.edit().remove("SELECTED_DATE").apply()
-                return true
-            }
-
-            R.id.calendar -> {
-                supportFragmentManager.beginTransaction().replace(
-                    R.id.main_fcv,
-                    CalendarFragment()
-                ).commit()
-                return true
-            }
-
-            R.id.route -> {
-                supportFragmentManager.beginTransaction().replace(
-                    R.id.main_fcv,
-                    RouteFragment()
-                ).commit()
-                return true
-            }
-            else -> return false
+    private fun switchFragment(tag: String, createFragment: () -> Fragment) {
+        val fragmentManager = supportFragmentManager
+        val targetFragment = fragmentManager.findFragmentByTag(tag) ?: createFragment()
+        val currentFragment = fragmentManager.fragments.firstOrNull { fragment ->
+            fragment.id == R.id.main_fcv && fragment.isAdded && !fragment.isHidden
         }
+
+        if (currentFragment === targetFragment) return
+
+        if (targetFragment is CalendarFragment && targetFragment.isAdded) {
+            targetFragment.showCalendarTab()
+        }
+
+        fragmentManager.beginTransaction().apply {
+            currentFragment?.let { hide(it) }
+
+            if (targetFragment.isAdded) {
+                show(targetFragment)
+            } else {
+                add(R.id.main_fcv, targetFragment, tag)
+            }
+        }.commit()
     }
 
     private fun createNotificationChannel() {

--- a/app/src/main/java/com/example/pace/ui/main/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/CalendarFragment.kt
@@ -79,7 +79,9 @@ class CalendarFragment: Fragment() {
 
 
         val calendarFragmentAdapter = CalendarFragmentAdapter(this)
+        binding.calendarVp.visibility = View.INVISIBLE
         binding.calendarVp.adapter = calendarFragmentAdapter
+        binding.calendarVp.offscreenPageLimit = 1
         binding.calendarVp.isUserInputEnabled = false
         binding.calendarVp.setCurrentItem(1, false)
         // 처음 진입 시 캘린더 탭이 기본이라 수정 버튼은 숨김
@@ -102,6 +104,11 @@ class CalendarFragment: Fragment() {
                 }
             }
         })
+
+        binding.calendarVp.post {
+            if (_binding == null) return@post
+            binding.calendarVp.visibility = View.VISIBLE
+        }
     }
 
     fun setTabVisibility(isVisible: Boolean) {
@@ -111,6 +118,33 @@ class CalendarFragment: Fragment() {
         // [수정] 원래 스와이프를 막기로 했다면, 여기서 다시 true로 만들면 안 됩니다.
         // 편집 모드든 아니든 뷰페이저는 터치로 넘기지 못하게 false로 박아버립니다.
         binding.calendarVp.isUserInputEnabled = false
+    }
+
+    fun showCalendarTab() {
+        if (_binding == null) return
+        binding.root.visibility = View.INVISIBLE
+        binding.calendarVp.setCurrentItem(1, false)
+        binding.calendarTabLayout.post {
+            if (_binding == null) return@post
+            binding.calendarTabLayout.selectTab(binding.calendarTabLayout.getTabAt(1), false)
+            binding.calendarTabLayout.setScrollPosition(1, 0f, true)
+            binding.root.visibility = View.VISIBLE
+        }
+    }
+
+    fun resetToTodayState() {
+        if (_binding == null) return
+
+        val today = java.time.LocalDate.now()
+        viewModel.setSelectedDate(today)
+        showCalendarTab()
+
+        childFragmentManager.fragments.forEach { fragment ->
+            when (fragment) {
+                is ScheduleListFragment -> fragment.resetToToday()
+                is CalendarPageFragment -> fragment.resetToTodayState()
+            }
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
@@ -81,6 +81,9 @@ class CalendarPageFragment: Fragment() {
     private var headerHeight = 0
     private var weekViewHeight = 0
     private var containerHeight = 0
+    private var isInitialLayoutReady = false
+    private var isInitialDataReady = false
+    private var hasShownInitialContent = false
 
 
     override fun onCreateView(
@@ -102,6 +105,8 @@ class CalendarPageFragment: Fragment() {
         val firstDayOfWeek = DayOfWeek.SUNDAY
         selectedMonth = currentMonth
         selectedDate = today
+        updateTitle()
+        updateSelectedDateText(today)
         viewModel.setSelectedDate(today) // 초기값 세팅
 
         setupCalendarLayout()
@@ -308,6 +313,8 @@ class CalendarPageFragment: Fragment() {
 
                 binding.calendarView.notifyCalendarChanged()
                 binding.weekCalendarView.notifyCalendarChanged()
+                isInitialDataReady = true
+                showInitialContentIfNeeded()
             }
         }
 
@@ -321,6 +328,33 @@ class CalendarPageFragment: Fragment() {
             }
         }
 
+    }
+
+    private fun showInitialContentIfNeeded() {
+        if (hasShownInitialContent || _binding == null) return
+        if (!isInitialLayoutReady || !isInitialDataReady) return
+        hasShownInitialContent = true
+
+        val targetMonth = selectedDate?.let { YearMonth.from(it) } ?: selectedMonth
+        val targetHeight = containerHeight - headerHeight
+
+        binding.calendarView.animate().cancel()
+        binding.weekCalendarView.animate().cancel()
+        binding.calendarView.scrollToMonth(targetMonth)
+        if (targetHeight > 0 && binding.calendarView.layoutParams.height != targetHeight) {
+            binding.calendarView.layoutParams.height = targetHeight
+            binding.calendarView.requestLayout()
+        }
+        binding.calendarView.alpha = 1f
+        binding.calendarView.visibility = View.VISIBLE
+        binding.weekCalendarView.alpha = 0f
+        binding.weekCalendarView.visibility = View.GONE
+
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+
+        binding.calendarContainer.visibility = View.VISIBLE
+        binding.bottomSheet.visibility = View.VISIBLE
+        binding.btnReturnToToday.visibility = if (selectedDate == today) View.GONE else View.VISIBLE
     }
 
     private fun setupCalendarLayout() {
@@ -345,6 +379,8 @@ class CalendarPageFragment: Fragment() {
                 if (availableHeight > 0 && binding.calendarView.layoutParams.height != availableHeight) {
                     binding.calendarView.layoutParams.height = availableHeight
                 }
+                isInitialLayoutReady = availableHeight > 0
+                showInitialContentIfNeeded()
             }
         })
     }
@@ -537,7 +573,7 @@ class CalendarPageFragment: Fragment() {
          * 3. 하루 일정 화면도 같은 날짜로 맞춘다.
          * 4. 같은 날짜를 다시 누르면 아래쪽 목록을 열거나 닫는다.
          */
-        if (selectedDate == date && scrollToPager && !fromScroll) {
+        if (selectedDate == date && scrollToPager && !fromScroll && hasShownInitialContent) {
             // 바텀시트 토글 로직 그대로 유지
             bottomSheetBehavior.state = if (bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {
                 BottomSheetBehavior.STATE_EXPANDED
@@ -577,10 +613,22 @@ class CalendarPageFragment: Fragment() {
                 binding.root.postDelayed({ isProgrammaticScroll = false }, 100)
             }
 
-            if (!fromScroll && bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {
+            if (hasShownInitialContent && !fromScroll && bottomSheetBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {
                 bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
             }
         }
+    }
+
+    fun resetToTodayState() {
+        if (_binding == null) return
+
+        val targetMonth = YearMonth.from(today)
+        selectedMonth = targetMonth
+        updateTitle()
+        selectDate(today, scrollToPager = true, fromScroll = true)
+        binding.calendarView.scrollToMonth(targetMonth)
+        binding.weekCalendarView.scrollToWeek(today)
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
     }
 
     private fun isDateInRecurrence(targetDate: LocalDate, startDate: LocalDate, rRule: String): Boolean {
@@ -700,6 +748,9 @@ class CalendarPageFragment: Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        isInitialLayoutReady = false
+        isInitialDataReady = false
+        hasShownInitialContent = false
         _binding = null
     }
 

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.example.pace.data.model.Schedule
 import com.example.pace.data.viewmodel.ScheduleViewModel
 import com.example.pace.databinding.FragmentScheduleListBinding
@@ -203,7 +204,7 @@ class ScheduleListFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
-                    viewModel.scheduleMap.collect { groupedMap ->
+                    viewModel.scheduleMap.collectLatest { groupedMap ->
                         groupedMap.values.flatten()
                             .filter { it.type == "ROUTE" }
                             .forEach { viewModel.fetchRouteDetail(it.id) }
@@ -213,8 +214,8 @@ class ScheduleListFragment : Fragment() {
                 }
 
                 launch {
-                    viewModel.routeDetails.collect {
-                        processAndDisplaySchedules(viewModel.scheduleMap.value)
+                    viewModel.routeDetails.collectLatest {
+                        scheduleListAdapter.updateRouteMap(it)
                     }
                 }
 
@@ -263,10 +264,8 @@ class ScheduleListFragment : Fragment() {
             }
         }
 
-        withContext(Dispatchers.Main) {
-            scheduleListAdapter.updateData(items, viewModel.routeDetails.value)
-            scrollToTodayPositionIfNeeded(todayPosition)
-        }
+        scheduleListAdapter.updateData(items, viewModel.routeDetails.value)
+        scrollToTodayPositionIfNeeded(todayPosition)
     }
 
     private fun scrollToTodayPositionIfNeeded(todayPosition: Int?) {
@@ -279,6 +278,14 @@ class ScheduleListFragment : Fragment() {
             if (!isAdded || _binding == null || hasScrolledToToday) return@post
             layoutManager.scrollToPositionWithOffset(targetPosition, 0)
             hasScrolledToToday = true
+        }
+    }
+
+    fun resetToToday() {
+        if (_binding == null) return
+        hasScrolledToToday = false
+        viewLifecycleOwner.lifecycleScope.launch {
+            processAndDisplaySchedules(viewModel.scheduleMap.value)
         }
     }
 

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListRVAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListRVAdapter.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.daimajia.swipe.SwipeLayout
@@ -17,6 +18,8 @@ import com.example.pace.databinding.ItemDateHeaderBinding
 import com.example.pace.databinding.ItemScheduleBinding
 import com.example.pace.ui.RouteCalculator
 import com.google.gson.Gson
+import java.time.LocalDate
+import java.time.LocalTime
 
 class ScheduleListRVAdapter(
     private val context: Context,
@@ -32,6 +35,9 @@ class ScheduleListRVAdapter(
     private var isEditMode = false
     private var selectedKeys = setOf<String>()
     private var routeInfoMap: Map<Long, RouteInfo> = emptyMap()
+    private val primaryTextColor by lazy { ContextCompat.getColor(context, R.color.black) }
+    private val secondaryTextColor by lazy { ContextCompat.getColor(context, R.color.text_secondary) }
+    private val disabledTextColor by lazy { ContextCompat.getColor(context, R.color.text_disabled) }
 
     companion object {
         private const val TYPE_HEADER = 0
@@ -60,6 +66,18 @@ class ScheduleListRVAdapter(
     fun updateSelectedKeys(keys: Set<String>) {
         selectedKeys = keys
         notifyDataSetChanged()
+    }
+
+    fun updateRouteMap(newRouteMap: Map<Long, RouteInfo>) {
+        if (routeInfoMap == newRouteMap) return
+        routeInfoMap = newRouteMap
+
+        items.forEachIndexed { index, item ->
+            val scheduleItem = item as? ScheduleListItem.ScheduleItem ?: return@forEachIndexed
+            if (scheduleItem.schedule.type == "ROUTE") {
+                notifyItemChanged(index)
+            }
+        }
     }
 
     fun getSelectedSchedules(keys: Set<String>): List<Schedule> {
@@ -161,7 +179,7 @@ class ScheduleListRVAdapter(
             val colorResId = schedule.eventColor.takeIf { it != null && it != 0 }
                 ?: schedule.calendarColor.takeIf { it != null && it != 0 }
                 ?: Color.parseColor("#A2BD3B")
-            binding.scheduleCategoryIv.imageTintList = ColorStateList.valueOf(colorResId)
+            applyTodayScheduleColors(schedule, colorResId)
 
             if (isEditMode) {
                 binding.scheduleCheckbox.visibility = View.VISIBLE
@@ -231,6 +249,43 @@ class ScheduleListRVAdapter(
             binding.root.addDrag(SwipeLayout.DragEdge.Right, binding.scheduleRightBottomWrapper)
 
             mItemManger.bindView(itemView, bindingAdapterPosition)
+        }
+
+        private fun applyTodayScheduleColors(schedule: Schedule, scheduleColor: Int) {
+            val today = LocalDate.now()
+            val scheduleDate = runCatching { LocalDate.parse(schedule.startDate.take(10)) }.getOrNull()
+            val isToday = scheduleDate == today
+            val isPastTimedSchedule = isToday &&
+                !schedule.isAllDay &&
+                runCatching { LocalTime.parse(schedule.endTime) }.getOrNull()?.isBefore(LocalTime.now()) == true
+
+            val titleColor = when {
+                isToday && schedule.isAllDay -> primaryTextColor
+                isPastTimedSchedule -> disabledTextColor
+                else -> primaryTextColor
+            }
+            val secondaryColor = if (isPastTimedSchedule) disabledTextColor else secondaryTextColor
+            val accentColor = if (isPastTimedSchedule) disabledTextColor else secondaryTextColor
+            val categoryColor = if (isPastTimedSchedule) {
+                (scheduleColor and 0x00FFFFFF) or (0x80 shl 24)
+            } else {
+                scheduleColor
+            }
+
+            binding.scheduleTitleTv.setTextColor(titleColor)
+            binding.scheduleTimeTv.setTextColor(secondaryColor)
+            binding.scheduleRepeatTv.setTextColor(secondaryColor)
+            binding.scheduleNormalLocationTv.setTextColor(secondaryColor)
+            binding.scheduleRouteNameTv.setTextColor(titleColor)
+            binding.scheduleRouteRangeTv.setTextColor(secondaryColor)
+            binding.scheduleRouteDurationTv.setTextColor(secondaryColor)
+
+            binding.scheduleCategoryIv.imageTintList = ColorStateList.valueOf(categoryColor)
+            binding.scheduleRepeatIv.imageTintList = ColorStateList.valueOf(accentColor)
+            binding.scheduleNormalLocationIv.imageTintList = ColorStateList.valueOf(accentColor)
+            binding.scheduleRouteLocationIv.imageTintList = ColorStateList.valueOf(accentColor)
+            binding.schedulePinnedIv.imageTintList =
+                if (isPastTimedSchedule) ColorStateList.valueOf(disabledTextColor) else null
         }
 
         private fun buildRouteName(

--- a/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
@@ -41,6 +41,8 @@ class HomeFragment: Fragment() {
     private lateinit var spf: SharedPreferences
     private lateinit var selectedDate: LocalDate
     private var scheduleMap: Map<LocalDate, List<Schedule>> = emptyMap()
+    private lateinit var horizontalCalendarAdapter: HorizontalCalendarRVAdapter
+    private var calendarCenterPosition = 0
 
 
     override fun onCreateView(
@@ -145,9 +147,10 @@ class HomeFragment: Fragment() {
         val date: LocalDate = selectedDate
         val layoutManager = binding.homeHorizontalCalendarRv.layoutManager as LinearLayoutManager
         val datePos = calendarSize / 2
+        calendarCenterPosition = datePos
         var calendarText = date.year.toString() + "년 " + date.monthValue.toString() + "월"
 
-        val horizontalCalendarAdapter = HorizontalCalendarRVAdapter(date)
+        horizontalCalendarAdapter = HorizontalCalendarRVAdapter(date)
         binding.homeHorizontalCalendarRv.adapter = horizontalCalendarAdapter
 
         val snapHelper = LinearSnapHelper()
@@ -287,6 +290,30 @@ class HomeFragment: Fragment() {
         modalCaseDialog?.dismiss()
         modalCaseDialog = null
         super.onStop()
+    }
+
+    fun resetToToday() {
+        if (!isAdded) return
+
+        selectedDate = LocalDate.now()
+        spf.edit().putString("SELECTED_DATE", selectedDate.toString()).apply()
+        viewModel.setSelectedDate(selectedDate)
+
+        if (::horizontalCalendarAdapter.isInitialized) {
+            val layoutManager = binding.homeHorizontalCalendarRv.layoutManager as? LinearLayoutManager
+            binding.homeHorizontalCalendarTv.text =
+                selectedDate.year.toString() + "년" + selectedDate.monthValue.toString() + "월"
+            horizontalCalendarAdapter.changeSelectedDate(calendarCenterPosition)
+            binding.homeHorizontalCalendarRv.post {
+                val recyclerLayoutManager = layoutManager ?: return@post
+                val screenWidth = binding.homeHorizontalCalendarRv.width
+                val itemWidth = screenWidth / 7
+                val offset = (screenWidth / 2) - (itemWidth / 2)
+                recyclerLayoutManager.scrollToPositionWithOffset(calendarCenterPosition, offset)
+            }
+        }
+
+        filterAndDisplaySchedules()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
@@ -3015,11 +3015,102 @@ class RouteFragment : Fragment() {
                 return@setOnClickListener
             }
 
-            val targetLocation = LatLng(location.latitude, location.longitude)
-            val mapFrag = childFragmentManager.findFragmentById(R.id.route_map_fcv) as? MapFragment
-            val supportMapFrag = mapFrag?.childFragmentManager?.findFragmentById(R.id.google_map_container) as? SupportMapFragment
-            supportMapFrag?.getMapAsync { googleMap ->
-                googleMap.animateCamera(com.google.android.gms.maps.CameraUpdateFactory.newLatLngZoom(targetLocation, 15f))
+            moveMapToCurrentLocation(location, animate = true)
+        }
+    }
+
+    fun resetToCurrentLocationState() {
+        if (_binding == null || !isAdded) return
+
+        hideKeyboard()
+        mainBinding?.searchEt?.clearFocus()
+        mainBinding?.searchEt?.setText("")
+
+        searchJob?.cancel()
+        realtimePollingJob?.cancel()
+        currentRealtimeParams = null
+        sessionToken = null
+
+        currentEntryMode = EntryMode.MAIN
+        currentTransitType = null
+        isStart = true
+        isDetailFromRecommend = false
+        isSelectingStart = true
+        isBookmarkSearchMode = false
+        wasRouteHeaderVisibleBeforeBookmark = false
+        bookmarkTarget = BookmarkTarget.NONE
+        selectedGroupId = null
+        selectedStartPlace = null
+        selectedEndPlace = null
+        selectedOnMapPlace = null
+        startLatLng = null
+        endLatLng = null
+        currentMapCenter = null
+        currentMapAddress = ""
+        currentMapCategory = ""
+        lastQuery = ""
+        isPoiMode = false
+        currentSortOption = RouteSortOption.BEST
+        requestSearchTime = ""
+        responseArrivelTime = ""
+        earlyArriveTime = -1
+        cachedScheduleData = null
+
+        binding.layoutRouteInputHeader.tvRouteStart.text = ""
+        binding.layoutRouteInputHeader.tvRouteEnd.text = ""
+        binding.layoutRouteInputHeader.tvSortFilter.text = currentSortOption.uiText
+        binding.layoutRouteInputHeader.root.visibility = View.GONE
+        binding.layoutRouteInputHeader.layoutFilterOptions.visibility = View.GONE
+        binding.layoutBookmarkHeader.root.visibility = View.GONE
+        binding.layoutMapSelectOverlay.root.visibility = View.GONE
+        binding.layoutRouteDetailOverlay.root.visibility = View.GONE
+        binding.layoutRouteDetailOverlay.bottomSheetRouteDetail.visibility = View.GONE
+        binding.routeSearchFcv.visibility = View.GONE
+        binding.routeMapFcv.visibility = View.VISIBLE
+
+        mainBinding?.mainToolbar?.visibility = View.VISIBLE
+        mainBinding?.mainBackIv?.visibility = View.GONE
+        mainBinding?.mainSearchLl?.visibility = View.VISIBLE
+        mainBinding?.mainBnv?.visibility = View.VISIBLE
+
+        val transaction = childFragmentManager.beginTransaction()
+        if (historyFragment.isAdded) transaction.hide(historyFragment)
+        if (recommendFragment.isAdded) transaction.hide(recommendFragment)
+        childFragmentManager.findFragmentByTag("ROUTE_RESULT")?.let { transaction.hide(it) }
+        transaction.commitAllowingStateLoss()
+        childFragmentManager.popBackStackImmediate("DETAIL", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+
+        val mapFrag = childFragmentManager.findFragmentById(R.id.route_map_fcv) as? MapFragment
+        mapFrag?.clearTemporaryMarker()
+        mapFrag?.clearMarkers()
+        mapFrag?.clearRoute()
+        mapFrag?.setMapPadding(0)
+        mapFrag?.updateButtonTranslation(0f)
+
+        if (::bottomSheetBehavior.isInitialized) {
+            bottomSheetBehavior.isHideable = true
+            bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+        }
+
+        mainActivity?.myLocation?.let {
+            currentMyLocation = LatLng(it.latitude, it.longitude)
+            moveMapToCurrentLocation(it, animate = false)
+        }
+    }
+
+    private fun moveMapToCurrentLocation(location: android.location.Location, animate: Boolean) {
+        val targetLocation = LatLng(location.latitude, location.longitude)
+        val mapFrag = childFragmentManager.findFragmentById(R.id.route_map_fcv) as? MapFragment
+        val supportMapFrag =
+            mapFrag?.childFragmentManager?.findFragmentById(R.id.google_map_container) as? SupportMapFragment
+
+        supportMapFrag?.getMapAsync { googleMap ->
+            val cameraUpdate =
+                com.google.android.gms.maps.CameraUpdateFactory.newLatLngZoom(targetLocation, 15f)
+            if (animate) {
+                googleMap.animateCamera(cameraUpdate)
+            } else {
+                googleMap.moveCamera(cameraUpdate)
             }
         }
     }

--- a/app/src/main/res/drawable/ic_pin.xml
+++ b/app/src/main/res/drawable/ic_pin.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="16dp" android:viewportHeight="12" android:viewportWidth="12" android:width="16dp">
 
-    <path android:fillColor="#00000000" android:pathData="M11.387,4.726L11.29,4.821L10.487,4.019L7.211,7.295L6.954,7.553L7.12,7.877C7.601,8.816 7.511,9.969 6.854,10.827L1.172,5.146C2.03,4.488 3.184,4.398 4.123,4.88L4.447,5.046L4.705,4.789L7.981,1.513L7.178,0.709L7.273,0.612L11.387,4.726ZM2.906,9.259L2.128,9.871L2.74,9.093L2.906,9.259Z" android:strokeColor="#666666" android:strokeWidth="1"/>
+    <path android:fillColor="#00000000" android:pathData="M11.387,4.726L11.29,4.821L10.487,4.019L7.211,7.295L6.954,7.553L7.12,7.877C7.601,8.816 7.511,9.969 6.854,10.827L1.172,5.146C2.03,4.488 3.184,4.398 4.123,4.88L4.447,5.046L4.705,4.789L7.981,1.513L7.178,0.709L7.273,0.612L11.387,4.726ZM2.906,9.259L2.128,9.871L2.74,9.093L2.906,9.259Z" android:strokeColor="@color/gray_600" android:strokeWidth="1"/>
     
 </vector>

--- a/app/src/main/res/layout/fragment_calendar_page.xml
+++ b/app/src/main/res/layout/fragment_calendar_page.xml
@@ -4,11 +4,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <!-- 기존 ConstraintLayout 내용을 통째로 감싸는 레이아웃 -->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/calendar_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:visibility="invisible">
 
         <LinearLayout
             android:id="@+id/header_container"
@@ -17,88 +17,88 @@
             android:orientation="vertical"
             app:layout_constraintTop_toTopOf="parent">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="horizontal"
-            android:padding="5dp">
-
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal"
                 android:padding="5dp">
 
-                <TextView
-                    android:id="@+id/calendar_number_picker_tv"
-                    android:layout_width="wrap_content"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="2026년 2월"
-                    android:textColor="@color/text_primary"
-                    android:textSize="18sp"
-                    android:clickable="true"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0.5"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    android:padding="5dp">
 
-                <ImageView
-                    android:id="@+id/calendar_number_picker_btn_iv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="5dp"
-                    android:clickable="true"
-                    android:src="@drawable/ic_calendar_picker"
-                    android:visibility="visible"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/calendar_number_picker_tv"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    <TextView
+                        android:id="@+id/calendar_number_picker_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:clickable="true"
+                        android:text=""
+                        android:textColor="@color/text_primary"
+                        android:textSize="18sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.5"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                    <ImageView
+                        android:id="@+id/calendar_number_picker_btn_iv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="5dp"
+                        android:clickable="true"
+                        android:src="@drawable/ic_calendar_picker"
+                        android:visibility="visible"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/calendar_number_picker_tv"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </LinearLayout>
+
+            <include
+                android:id="@+id/legendLayout"
+                layout="@layout/layout_calendar_day_legend" />
+
         </LinearLayout>
 
-        <include
-            android:id="@+id/legendLayout"
-            layout="@layout/layout_calendar_day_legend" />
+        <com.kizitonwose.calendar.view.CalendarView
+            android:id="@+id/calendarView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            app:cv_daySize="rectangle"
+            app:cv_dayViewResource="@layout/item_calendar_day"
+            app:layout_constraintTop_toBottomOf="@id/header_container" />
 
-    </LinearLayout>
-
-    <com.kizitonwose.calendar.view.CalendarView
-        android:id="@+id/calendarView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginEnd="20dp"
-        app:cv_dayViewResource="@layout/item_calendar_day"
-        app:cv_daySize="rectangle"
-        app:layout_constraintTop_toBottomOf="@id/header_container"/>
-
-    <com.kizitonwose.calendar.view.WeekCalendarView
-        android:id="@+id/weekCalendarView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginEnd="20dp"
-        app:cv_dayViewResource="@layout/item_calendar_day"
-        app:cv_daySize="rectangle"
-        app:layout_constraintTop_toBottomOf="@id/header_container"
-        android:visibility="invisible"/>
+        <com.kizitonwose.calendar.view.WeekCalendarView
+            android:id="@+id/weekCalendarView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:visibility="invisible"
+            app:cv_daySize="rectangle"
+            app:cv_dayViewResource="@layout/item_calendar_day"
+            app:layout_constraintTop_toBottomOf="@id/header_container" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <FrameLayout
         android:id="@+id/bottom_sheet"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:visibility="invisible"
         app:behavior_hideable="true"
-        app:behavior_peekHeight="0dp">
+        app:behavior_peekHeight="0dp"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <include
             android:id="@+id/schedule_list_container"
             layout="@layout/bottom_sheet_schedule" />
-
     </FrameLayout>
 
     <LinearLayout
@@ -107,16 +107,16 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|center_horizontal"
         android:layout_marginBottom="30dp"
+        android:alpha="0"
         android:background="@drawable/bg_return_to_today"
+        android:clickable="true"
         android:elevation="8dp"
+        android:focusable="true"
         android:gravity="center"
         android:orientation="horizontal"
         android:paddingHorizontal="16dp"
         android:paddingVertical="10dp"
-        android:clickable="true"
-        android:focusable="true"
-        android:visibility="gone"
-        android:alpha="0">
+        android:visibility="gone">
 
         <TextView
         android:layout_width="wrap_content"


### PR DESCRIPTION
- [FEAT]
# PR템플릿 

## 변경 사항 요약
- 메인 액티비티 하위의 프래그먼트들이 상태를 유지하게 하여 초기 로딩 시간 제거
(홈프래그먼트, 스케줄 리스트프래그먼트, 캘린더프래그먼트, 캘린더페이지프래그먼트, 루트프래그먼트) 총 5개
- 상태 유지에 의한 초기화 누락에 따른 초기화 코드 추가
- 일정탭 캘린더 초기 로딩 버벅임 해결
- 완료된 일정 회색표시
- 바텀탭 동일한 탭 연타 시 재로딩 방지
- 고정 핀 아이콘 색상 변경

## 체크리스트
- [v] 코드 빌드 성공
- [v] 에뮬레이터 실행 시 성공

## 사진올리는곳
