### PR TITLE
Refactor/onestone qa 3 1

### DIFF
--- a/app/src/main/java/com/example/pace/data/datasource/NormalScheduleRemoteDataSource.kt
+++ b/app/src/main/java/com/example/pace/data/datasource/NormalScheduleRemoteDataSource.kt
@@ -20,9 +20,6 @@ import javax.inject.Inject
 class NormalScheduleRemoteDataSource @Inject constructor(
     @ApplicationContext private val applicationContext: Context
 ) {
-    companion object {
-        private const val REPEAT_DEBUG_TAG = "RepeatDebug"
-    }
 
     suspend fun insertToCalendarProvider(
         request: CreateScheduleRequest,
@@ -40,16 +37,6 @@ class NormalScheduleRemoteDataSource @Inject constructor(
         )
 
         val generatedRrule = buildRRule(request.repeatInfo)
-        if (generatedRrule != null) {
-            Log.d(
-                REPEAT_DEBUG_TAG,
-                "반복 일정 생성 요청: title=${request.title}, isAllDay=${request.isAllDay}, startDate=${request.startDate}, endDate=${request.endDate}, startTime=${request.startTime}, endTime=${request.endTime}, repeatInfo=${request.repeatInfo}"
-            )
-            Log.d(
-                REPEAT_DEBUG_TAG,
-                "반복 일정 계산값: dtStart=${timing.startMillis}, dtEnd=${timing.endMillis}, duration=${timing.durationForRecurring}, timezone=${timing.timeZoneId}, rrule=$generatedRrule"
-            )
-        }
 
         val values = ContentValues().apply {
             put(CalendarContract.Events.TITLE, request.title)
@@ -216,12 +203,6 @@ class NormalScheduleRemoteDataSource @Inject constructor(
                     val calendarColor = it.getInt(calColorIdx)
 
                     val reminders = fetchReminders(id)
-                    if (!rrule.isNullOrEmpty()) {
-                        Log.d(
-                            REPEAT_DEBUG_TAG,
-                            "반복 일정 조회값: id=$id, title=$title, dtStart=$dtStart, rawDtEnd=$dtEnd, duration=$durationStr, isAllDay=$isAllDay, startDate=$startDate, endDate=$endDate, startTime=$startTime, endTime=$endTime, rrule=$rrule"
-                        )
-                    }
 
                     scheduleList.add(
                         Schedule(

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
@@ -63,7 +63,6 @@ class ScheduleRepositoryImpl @Inject constructor(
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
         private const val SWAGGER_LOG_TAG = "SwaggerScheduleRequest"
         private const val LOG_CHUNK_SIZE = 3000
-        private const val REPEAT_EXPAND_TAG = "RepeatExpand"
     }
 
     // Expose schedules after recurrence expansion
@@ -234,7 +233,6 @@ class ScheduleRepositoryImpl @Inject constructor(
                     }
 
                     scheduleDao.insertAll(mergedSchedules)
-                    Log.d("SYNC_LOG", "1. 기기 일정 병합 후 로컬 DB 업데이트 완료")
                 }
 
                 if (systemIds.isNotEmpty()) {
@@ -242,7 +240,7 @@ class ScheduleRepositoryImpl @Inject constructor(
                 }
             }
         } catch (e: Exception) {
-            Log.e("SYNC_LOG", "새로고침 중 예외 발생: ${e.message}")
+            Log.e("ScheduleRepository", "새로고침 중 예외 발생: ${e.message}")
         }
     }
 
@@ -794,12 +792,6 @@ class ScheduleRepositoryImpl @Inject constructor(
                             }
                             val occurrenceEndLocalDate = occurrenceLocalDate.plusDays(spanDays)
                             val formattedDate = occurrenceLocalDate.format(dateFormatter)
-                            if (schedule.isAllDay) {
-                                Log.d(
-                                    REPEAT_EXPAND_TAG,
-                                    "반복 확장: id=${schedule.id}, title=${schedule.title}, original=${schedule.startDate}~${schedule.endDate}, occurrence=${formattedDate}~${occurrenceEndLocalDate.format(dateFormatter)}, rawInstant=${occurrenceDate.toInstant()}"
-                                )
-                            }
 
                             val systemDeletedDates = cancellationMap[schedule.id] ?: emptyList()
                             if (systemDeletedDates.contains(formattedDate)) {
@@ -955,6 +947,69 @@ class ScheduleRepositoryImpl @Inject constructor(
             serverId = this.scheduleId,
             repeatRule = null,
             exDate = null
+        )
+    }
+
+    private suspend fun syncServerScheduleDetail(accessToken: String, scheduleId: Long) {
+        val detailResponse = api.getScheduleDetail(accessToken, scheduleId)
+        if (!detailResponse.isSuccess || detailResponse.result == null) {
+            Log.w("UpdateFlow", "Route schedule detail sync skipped: ${detailResponse.message}")
+            return
+        }
+
+        val existing = scheduleDao.getScheduleById(scheduleId)
+        scheduleDao.insertSingle(detailResponse.result.toScheduleEntity(existing))
+    }
+
+    private fun ScheduleDetailResponse.toScheduleEntity(existing: Schedule?): Schedule {
+        val colorHex = scheduleInfo.color ?: "#DC354B"
+        val colorInt = try {
+            android.graphics.Color.parseColor(colorHex)
+        } catch (e: Exception) {
+            android.graphics.Color.parseColor("#DC354B")
+        }
+        val serverCalendarId = scheduleInfo.calendarId?.toLongOrNull()
+            ?: existing?.calendarId
+            ?: 1L
+        val eventRemindersList = reminders
+            .filter { it.reminderType == "EVENT" }
+            .map { it.minutesBefore }
+        val departureRemindersList = reminders
+            .filter { it.reminderType == "DEPARTURE" }
+            .map { it.minutesBefore }
+        val gson = Gson()
+        val placeJsonString = place?.let { gson.toJson(it) }
+        val routeJsonString = route?.let { gson.toJson(it) }
+        val isRouteType = (scheduleInfo.isPathIncluded == true) || (route != null)
+
+        return Schedule(
+            id = scheduleId,
+            title = scheduleInfo.title,
+            startDate = scheduleInfo.startDate,
+            endDate = scheduleInfo.endDate,
+            startTime = scheduleInfo.startTime?.take(5) ?: "00:00",
+            endTime = scheduleInfo.endTime?.take(5) ?: "23:59",
+            isAllDay = scheduleInfo.isAllDay,
+            memo = scheduleInfo.memo,
+            location = route?.destName ?: place?.targetName,
+            calendarId = serverCalendarId,
+            calendarDisplayName = existing?.calendarDisplayName ?: "기본 일정",
+            calendarAccountName = existing?.calendarAccountName ?: "Pace",
+            reminders = eventRemindersList,
+            departureReminders = departureRemindersList,
+            withRoute = isRouteType,
+            isCompleted = existing?.isCompleted ?: false,
+            isPinned = existing?.isPinned ?: false,
+            isSwiped = existing?.isSwiped ?: false,
+            type = if (isRouteType) "ROUTE" else "NORMAL",
+            eventColor = colorInt,
+            calendarColor = colorInt,
+            serverId = scheduleId,
+            sourceType = "SERVER",
+            placeJson = placeJsonString,
+            routeJson = routeJsonString,
+            repeatRule = existing?.repeatRule,
+            exDate = existing?.exDate
         )
     }
 
@@ -1208,6 +1263,7 @@ class ScheduleRepositoryImpl @Inject constructor(
             )
 
             if (putRes.isSuccess) {
+                syncServerScheduleDetail(accessToken, scheduleId)
                 Log.d("UpdateFlow", "3단계 - 경로 정보 갱신 완료")
                 putRes
             } else {
@@ -1307,7 +1363,7 @@ class ScheduleRepositoryImpl @Inject constructor(
         withContext(Dispatchers.IO) {
             WorkManager.getInstance(context).cancelUniqueWork("finalize_$scheduleId")
             scheduleDao.deleteScheduleById(scheduleId)
-            Log.d("SYNC_LOG", "404 응답으로 경로 일정 로컬 정리: $scheduleId")
+            Log.d("ScheduleRepository", "404 응답으로 경로 일정 로컬 정리: $scheduleId")
         }
     }
 
@@ -1334,7 +1390,7 @@ class ScheduleRepositoryImpl @Inject constructor(
         }
 
         scheduleDao.deleteSchedulesByIds(staleRouteIds)
-        Log.d("SYNC_LOG", "서버에서 삭제된 경로 일정 정리 완료: ${staleRouteIds.joinToString()}")
+        Log.d("ScheduleRepository", "서버에서 삭제된 경로 일정 정리 완료: ${staleRouteIds.joinToString()}")
     }
 
 }

--- a/app/src/main/java/com/example/pace/data/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/example/pace/data/viewmodel/ScheduleViewModel.kt
@@ -257,6 +257,12 @@ class ScheduleViewModel @Inject constructor(
         searchSchedules(lastQuery)
     }
 
+    private fun refreshSearchResultsIfNeeded() {
+        if (lastQuery.isNotBlank()) {
+            searchSchedules(lastQuery)
+        }
+    }
+
     // Calendar list exposed to UI
     val scheduleMap: StateFlow<Map<LocalDate, List<Schedule>>> = combine(
         repository.allSchedules,
@@ -330,21 +336,25 @@ class ScheduleViewModel @Inject constructor(
                 if (schedule.type == "ROUTE") {
                     // Route schedules are updated through the server API
                     val request = mapScheduleToRequest(schedule)
+                    val targetScheduleId = schedule.serverId ?: schedule.id
+                    val existingSchedule = repository.getScheduleById(targetScheduleId)
 
                     val token = authDataStore.getAccessToken() ?: ""
                     val fullToken = if (token.isNotEmpty() && !token.startsWith("Bearer ")) "Bearer $token" else token
 
                     val response = repository.updateRouteSchedule(
                         accessToken = fullToken,
-                        scheduleId = schedule.serverId ?: schedule.id,
+                        scheduleId = targetScheduleId,
                         request = request,
                         calendarId = schedule.calendarId,
                         selectedColor = schedule.eventColor ?: 0
                     )
 
                     if (response.isSuccess) {
-                        val targetScheduleId = schedule.serverId ?: schedule.id
-                        replaceRouteScheduleRuntime(targetScheduleId)
+                        replaceRouteScheduleRuntime(
+                            previousSchedule = existingSchedule,
+                            scheduleId = targetScheduleId
+                        )
                         _updateScheduleEvent.value = true
                         Log.d("ScheduleViewModel", "경로 일정 서버 수정 성공")
                     } else {
@@ -409,6 +419,10 @@ class ScheduleViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             try {
+                val existingSchedule = withContext(Dispatchers.IO) {
+                    repository.getScheduleById(scheduleId)
+                }
+
                 // Prepare token
                 val token = authDataStore.getAccessToken() ?: ""
                 val fullToken = if (token.isNotEmpty() && !token.startsWith("Bearer ")) "Bearer $token" else token
@@ -425,7 +439,10 @@ class ScheduleViewModel @Inject constructor(
                 // Handle result
                 if (response.isSuccess) {
                     withContext(Dispatchers.IO) {
-                        replaceRouteScheduleRuntime(scheduleId)
+                        replaceRouteScheduleRuntime(
+                            previousSchedule = existingSchedule,
+                            scheduleId = scheduleId
+                        )
                     }
                     _updateScheduleEvent.value = true
                     Log.d("ScheduleViewModel", "경로 일정 서버 수정 성공: $scheduleId")
@@ -667,7 +684,6 @@ class ScheduleViewModel @Inject constructor(
             Log.e("DeleteLog", "일반 일정 삭제 실패: ${response.message}")
         }
     }
-
     // Delete route schedule through server API and local DB
     private suspend fun deleteRouteSchedule(id: Long) {
         Log.d("DeleteLog", "경로 일정 삭제 시도: ID = $id")
@@ -678,6 +694,7 @@ class ScheduleViewModel @Inject constructor(
                 cancelRouteScheduleRuntime(schedule)
             }
             Log.d("DeleteLog", "경로 일정 삭제 성공")
+            refreshSearchResultsIfNeeded()
         } else {
             Log.e("DeleteLog", "서버 삭제 실패: ${response.message}")
         }
@@ -693,6 +710,7 @@ class ScheduleViewModel @Inject constructor(
             // Server schedules keep local-only EXDATE overrides in Room,
             // and a full sync would overwrite them immediately.
             repository.refreshSchedules()
+            refreshSearchResultsIfNeeded()
 
             Log.d("ExDateLog", "작업 완료 후 새로고침 호출")
         }
@@ -721,6 +739,8 @@ class ScheduleViewModel @Inject constructor(
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
+                val existingSchedule = repository.getScheduleById(scheduleId)
+
                 // Prepare token
                 val token = authDataStore.getAccessToken() ?: ""
                 val fullToken = if (token.startsWith("Bearer ")) token else "Bearer $token"
@@ -736,7 +756,11 @@ class ScheduleViewModel @Inject constructor(
 
                 if (response.isSuccess) {
                     val arrival = routeRequest.arrivalTime
-                    replaceRouteScheduleRuntime(scheduleId, arrival)
+                    replaceRouteScheduleRuntime(
+                        previousSchedule = existingSchedule,
+                        scheduleId = scheduleId,
+                        arrivalTimeOverride = arrival
+                    )
                     withContext(Dispatchers.Main) {
                         _updateScheduleEvent.value = true
                     }
@@ -771,11 +795,14 @@ class ScheduleViewModel @Inject constructor(
         scheduleFinalize(schedule, arrivalTimeOverride)
     }
 
-    private suspend fun replaceRouteScheduleRuntime(scheduleId: Long, arrivalTimeOverride: String? = null) {
-        repository.getScheduleById(scheduleId)?.let { existing ->
+    private suspend fun replaceRouteScheduleRuntime(
+        previousSchedule: Schedule?,
+        scheduleId: Long,
+        arrivalTimeOverride: String? = null
+    ) {
+        previousSchedule?.let { existing ->
             cancelRouteScheduleRuntime(existing)
         }
-        repository.refreshSchedules()
         repository.getScheduleById(scheduleId)?.let { updated ->
             syncRouteScheduleRuntime(updated, arrivalTimeOverride)
         }

--- a/app/src/main/java/com/example/pace/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/pace/ui/main/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.fragment.app.Fragment
 import com.example.pace.R
 import com.example.pace.databinding.ActivityMainBinding
 import com.example.pace.ui.main.calendar.CalendarFragment
+import com.example.pace.ui.main.calendar.SearchFragment
 import com.example.pace.ui.main.home.HomeFragment
 import com.example.pace.ui.main.route.RouteFragment
 import com.example.pace.ui.search_box.*
@@ -277,9 +278,12 @@ class MainActivity : AppCompatActivity() {
             }
 
             R.id.calendar -> {
+                val skipCalendarReset = supportFragmentManager.findFragmentById(R.id.main_fcv) is SearchFragment
                 switchFragment(TAG_CALENDAR) { CalendarFragment() }
                 supportFragmentManager.executePendingTransactions()
-                (supportFragmentManager.findFragmentByTag(TAG_CALENDAR) as? CalendarFragment)?.resetToTodayState()
+                if (!skipCalendarReset) {
+                    (supportFragmentManager.findFragmentByTag(TAG_CALENDAR) as? CalendarFragment)?.resetToTodayState()
+                }
                 currentBottomMenuItem = R.id.calendar
                 binding.mainLogoIv.visibility = android.view.View.GONE
                 binding.mainSettingsIv.visibility = android.view.View.GONE

--- a/app/src/main/java/com/example/pace/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/pace/ui/main/MainActivity.kt
@@ -245,8 +245,10 @@ class MainActivity : AppCompatActivity() {
     private fun handleIntent(intent: Intent?) {
         val actionMode = intent?.getStringExtra("ACTION_MODE")
 
-        if (actionMode == "SCHEDULE" || actionMode == "SCHEDULE_ROUTE") {
-            binding.mainBnv.selectedItemId = R.id.route
+        if (actionMode == "SCHEDULE" || actionMode == "SCHEDULE_ROUTE" || actionMode == "ROUTE_RESEARCH") {
+            showRouteTab(resetIfNeeded = false)
+            (supportFragmentManager.findFragmentByTag(TAG_ROUTE) as? RouteFragment)
+                ?.consumeActionModeIntent(intent)
         }
     }
 
@@ -298,23 +300,31 @@ class MainActivity : AppCompatActivity() {
             }
 
             R.id.route -> {
-                switchFragment(TAG_ROUTE) { RouteFragment() }
-                supportFragmentManager.executePendingTransactions()
-                (supportFragmentManager.findFragmentByTag(TAG_ROUTE) as? RouteFragment)?.resetToCurrentLocationState()
-                currentBottomMenuItem = R.id.route
-                binding.mainLogoIv.visibility = android.view.View.GONE
-                binding.mainSettingsIv.visibility = android.view.View.GONE
-                binding.scheduleTitleTv.visibility = android.view.View.GONE
-                binding.scheduleActionContainer.visibility = View.GONE
-                binding.scheduleEditIv.visibility = android.view.View.GONE
-                binding.scheduleSearchIv.visibility = android.view.View.GONE
-                binding.scheduleAddIv.visibility = View.GONE
-                binding.mainBackIv.visibility = android.view.View.GONE
-                binding.mainSearchLl.visibility = android.view.View.VISIBLE
+                showRouteTab(resetIfNeeded = true)
                 return true
             }
             else -> return false
         }
+    }
+
+    private fun showRouteTab(resetIfNeeded: Boolean) {
+        switchFragment(TAG_ROUTE) { RouteFragment() }
+        supportFragmentManager.executePendingTransactions()
+        val routeFragment = supportFragmentManager.findFragmentByTag(TAG_ROUTE) as? RouteFragment
+        if (resetIfNeeded && routeFragment?.isInScheduleSelectionMode() != true) {
+            routeFragment?.resetToCurrentLocationState()
+        }
+        currentBottomMenuItem = R.id.route
+        binding.mainBnv.menu.findItem(R.id.route)?.isChecked = true
+        binding.mainLogoIv.visibility = android.view.View.GONE
+        binding.mainSettingsIv.visibility = android.view.View.GONE
+        binding.scheduleTitleTv.visibility = android.view.View.GONE
+        binding.scheduleActionContainer.visibility = View.GONE
+        binding.scheduleEditIv.visibility = android.view.View.GONE
+        binding.scheduleSearchIv.visibility = android.view.View.GONE
+        binding.scheduleAddIv.visibility = android.view.View.GONE
+        binding.mainBackIv.visibility = android.view.View.GONE
+        binding.mainSearchLl.visibility = android.view.View.VISIBLE
     }
     // 같은 프래그먼트 선택 시 새로고침
     private fun switchFragment(tag: String, createFragment: () -> Fragment) {

--- a/app/src/main/java/com/example/pace/ui/main/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/CalendarFragment.kt
@@ -21,6 +21,8 @@ import dagger.hilt.android.AndroidEntryPoint // 추가
 class CalendarFragment: Fragment() {
     private var _binding: FragmentCalendarBinding? = null
     private val binding get() = _binding!!
+    private var pendingResetToTodayState = false
+    private var currentTabIndex = 1
 
     private val viewModel: ScheduleViewModel by activityViewModels()
     override fun onCreateView(
@@ -83,9 +85,8 @@ class CalendarFragment: Fragment() {
         binding.calendarVp.adapter = calendarFragmentAdapter
         binding.calendarVp.offscreenPageLimit = 1
         binding.calendarVp.isUserInputEnabled = false
-        binding.calendarVp.setCurrentItem(1, false)
-        // 처음 진입 시 캘린더 탭이 기본이라 수정 버튼은 숨김
-        mainActivity.binding.scheduleEditIv.visibility = View.GONE
+        binding.calendarVp.setCurrentItem(currentTabIndex, false)
+        updateHeaderForTab(currentTabIndex)
 
         val tabTitles = listOf("리스트", "캘린더")
         TabLayoutMediator(binding.calendarTabLayout, binding.calendarVp) { tab, position ->
@@ -97,11 +98,8 @@ class CalendarFragment: Fragment() {
         binding.calendarVp.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                val mainActivity = requireActivity() as MainActivity
-                when (position) {
-                    0 -> mainActivity.binding.scheduleEditIv.visibility = View.VISIBLE  // List tab
-                    1 -> mainActivity.binding.scheduleEditIv.visibility = View.GONE     // Calendar tab
-                }
+                currentTabIndex = position
+                updateHeaderForTab(position)
             }
         })
 
@@ -109,6 +107,8 @@ class CalendarFragment: Fragment() {
             if (_binding == null) return@post
             binding.calendarVp.visibility = View.VISIBLE
         }
+
+        applyPendingResetIfNeeded()
     }
 
     fun setTabVisibility(isVisible: Boolean) {
@@ -122,18 +122,24 @@ class CalendarFragment: Fragment() {
 
     fun showCalendarTab() {
         if (_binding == null) return
+        currentTabIndex = 1
         binding.root.visibility = View.INVISIBLE
-        binding.calendarVp.setCurrentItem(1, false)
+        binding.calendarVp.setCurrentItem(currentTabIndex, false)
+        updateHeaderForTab(currentTabIndex)
         binding.calendarTabLayout.post {
             if (_binding == null) return@post
-            binding.calendarTabLayout.selectTab(binding.calendarTabLayout.getTabAt(1), false)
-            binding.calendarTabLayout.setScrollPosition(1, 0f, true)
+            binding.calendarTabLayout.selectTab(binding.calendarTabLayout.getTabAt(currentTabIndex), false)
+            binding.calendarTabLayout.setScrollPosition(currentTabIndex, 0f, true)
             binding.root.visibility = View.VISIBLE
         }
     }
 
     fun resetToTodayState() {
-        if (_binding == null) return
+        if (_binding == null) {
+            pendingResetToTodayState = true
+            return
+        }
+        pendingResetToTodayState = false
 
         val today = java.time.LocalDate.now()
         viewModel.setSelectedDate(today)
@@ -143,6 +149,27 @@ class CalendarFragment: Fragment() {
             when (fragment) {
                 is ScheduleListFragment -> fragment.resetToToday()
                 is CalendarPageFragment -> fragment.resetToTodayState()
+            }
+        }
+    }
+
+    private fun applyPendingResetIfNeeded() {
+        if (!pendingResetToTodayState || _binding == null) return
+        resetToTodayState()
+    }
+
+    private fun updateHeaderForTab(position: Int) {
+        val activity = activity as? MainActivity ?: return
+        when (position) {
+            0 -> {
+                activity.binding.scheduleEditIv.visibility = View.VISIBLE
+                activity.binding.scheduleSearchIv.visibility = View.VISIBLE
+                activity.binding.scheduleAddIv.visibility = View.VISIBLE
+            }
+            else -> {
+                activity.binding.scheduleEditIv.visibility = View.GONE
+                activity.binding.scheduleSearchIv.visibility = View.VISIBLE
+                activity.binding.scheduleAddIv.visibility = View.VISIBLE
             }
         }
     }

--- a/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/CalendarPageFragment.kt
@@ -84,6 +84,7 @@ class CalendarPageFragment: Fragment() {
     private var isInitialLayoutReady = false
     private var isInitialDataReady = false
     private var hasShownInitialContent = false
+    private var pendingResetToTodayState = false
 
 
     override fun onCreateView(
@@ -255,6 +256,7 @@ class CalendarPageFragment: Fragment() {
         // 초기 날짜 텍스트 설정
         updateSelectedDateText(today)
         binding.btnReturnToToday.visibility = if (selectedDate == today) View.GONE else View.VISIBLE
+        applyPendingResetIfNeeded()
     }
 
     // 상단 텍스트 업데이트
@@ -620,7 +622,11 @@ class CalendarPageFragment: Fragment() {
     }
 
     fun resetToTodayState() {
-        if (_binding == null) return
+        if (_binding == null || !::bottomSheetBehavior.isInitialized) {
+            pendingResetToTodayState = true
+            return
+        }
+        pendingResetToTodayState = false
 
         val targetMonth = YearMonth.from(today)
         selectedMonth = targetMonth
@@ -629,6 +635,11 @@ class CalendarPageFragment: Fragment() {
         binding.calendarView.scrollToMonth(targetMonth)
         binding.weekCalendarView.scrollToWeek(today)
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+    }
+
+    private fun applyPendingResetIfNeeded() {
+        if (!pendingResetToTodayState || _binding == null || !::bottomSheetBehavior.isInitialized) return
+        resetToTodayState()
     }
 
     private fun isDateInRecurrence(targetDate: LocalDate, startDate: LocalDate, rRule: String): Boolean {

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListFragment.kt
@@ -18,6 +18,7 @@ import com.example.pace.data.viewmodel.ScheduleViewModel
 import com.example.pace.databinding.FragmentScheduleListBinding
 import com.example.pace.ui.add_schedule.AddScheduleActivity
 import com.example.pace.ui.main.MainActivity
+import com.example.pace.ui.main.calendar.SearchFragment
 import com.example.pace.ui.main.home.DeleteRepeatScheduleDialog
 import com.example.pace.ui.main.home.DeleteScheduleDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -37,6 +38,7 @@ class ScheduleListFragment : Fragment() {
     private lateinit var scheduleListAdapter: ScheduleListRVAdapter
     private val viewModel: ScheduleViewModel by activityViewModels()
     private var hasScrolledToToday = false
+    private var pendingResetToToday = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -54,6 +56,7 @@ class ScheduleListFragment : Fragment() {
         setupObservers()
         observeEditMode()
         setupEditBarButtons()
+        applyPendingResetIfNeeded()
     }
 
     private fun setupOnBackPressed() {
@@ -79,6 +82,9 @@ class ScheduleListFragment : Fragment() {
             viewModel.isEditMode.collectLatest { isEditMode ->
                 val mainActivity = requireActivity() as MainActivity
                 val parent = parentFragment as? CalendarFragment
+                val currentMainFragment = requireActivity()
+                    .supportFragmentManager
+                    .findFragmentById(com.example.pace.R.id.main_fcv)
 
                 binding.layoutEditHeader.visibility = if (isEditMode) View.VISIBLE else View.GONE
 
@@ -90,7 +96,9 @@ class ScheduleListFragment : Fragment() {
                 } else {
                     binding.layoutEditBar.visibility = View.GONE
                     mainActivity.binding.mainBnv.visibility = View.VISIBLE
-                    mainActivity.binding.mainToolbar.visibility = View.VISIBLE
+                    if (currentMainFragment !is SearchFragment) {
+                        mainActivity.binding.mainToolbar.visibility = View.VISIBLE
+                    }
                     parent?.setTabVisibility(true)
                 }
 
@@ -282,11 +290,20 @@ class ScheduleListFragment : Fragment() {
     }
 
     fun resetToToday() {
-        if (_binding == null) return
+        if (_binding == null) {
+            pendingResetToToday = true
+            return
+        }
+        pendingResetToToday = false
         hasScrolledToToday = false
         viewLifecycleOwner.lifecycleScope.launch {
             processAndDisplaySchedules(viewModel.scheduleMap.value)
         }
+    }
+
+    private fun applyPendingResetIfNeeded() {
+        if (!pendingResetToToday || _binding == null) return
+        resetToToday()
     }
 
     private fun formatDateToHeader(date: LocalDate): String {

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListRVAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListRVAdapter.kt
@@ -185,7 +185,7 @@ class ScheduleListRVAdapter(
                 binding.scheduleCheckbox.visibility = View.VISIBLE
                 binding.scheduleCheckbox.isChecked = selectedKeys.contains(selectionKey(schedule))
                 binding.scheduleCheckbox.isClickable = false
-                binding.schedulePinnedIv.visibility = View.GONE
+                binding.schedulePinnedIv.visibility = if (schedule.isPinned) View.VISIBLE else View.GONE
             } else {
                 binding.scheduleCheckbox.visibility = View.GONE
                 binding.schedulePinnedIv.visibility = if (schedule.isPinned) View.VISIBLE else View.GONE

--- a/app/src/main/java/com/example/pace/ui/main/calendar/SearchAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/SearchAdapter.kt
@@ -10,13 +10,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.daimajia.swipe.SwipeLayout
+import com.daimajia.swipe.adapters.RecyclerSwipeAdapter
 import com.example.pace.R
 import com.example.pace.data.model.Schedule
 import com.example.pace.data.model.response.RouteInfo
 import com.example.pace.databinding.ItemDateHeaderBinding
 import com.example.pace.databinding.ItemScheduleBinding
 import com.example.pace.ui.RouteCalculator
-import com.example.pace.ui.main.home.ScheduleTouchHelper
 import com.google.gson.Gson
 
 class SearchAdapter(
@@ -27,12 +28,10 @@ class SearchAdapter(
     private val onEditClick: (Schedule) -> Unit,
     private val onEditSelect: (Long) -> Unit,
     private var routeInfoMap: Map<Long, RouteInfo> = emptyMap()
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+) : RecyclerSwipeAdapter<RecyclerView.ViewHolder>() {
 
     private val gson = Gson()
-
     private var items = listOf<ScheduleListItem>()
-    lateinit var scheduleTouchHelper: ScheduleTouchHelper
     private var selectedIds = setOf<Long>()
 
     companion object {
@@ -131,15 +130,17 @@ class SearchAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        holder.itemView.findViewById<View>(R.id.schedule_view_top)?.translationX = 0f
-
         when (val item = items[position]) {
             is ScheduleListItem.DateHeader -> (holder as DateHeaderViewHolder).bind(item.date)
-            is ScheduleListItem.ScheduleItem -> (holder as SearchItemViewHolder).bind(item.schedule, query, holder)
+            is ScheduleListItem.ScheduleItem -> (holder as SearchItemViewHolder).bind(item.schedule, query)
         }
     }
 
     override fun getItemCount(): Int = items.size
+
+    override fun getSwipeLayoutResourceId(position: Int): Int {
+        return if (getItemViewType(position) == TYPE_SCHEDULE_ITEM) R.id.item_schedule else 0
+    }
 
     inner class DateHeaderViewHolder(private val binding: ItemDateHeaderBinding) :
         RecyclerView.ViewHolder(binding.root) {
@@ -151,7 +152,7 @@ class SearchAdapter(
     inner class SearchItemViewHolder(private val binding: ItemScheduleBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(schedule: Schedule, query: String, holder: RecyclerView.ViewHolder) {
+        fun bind(schedule: Schedule, query: String) {
             val title = schedule.title ?: "제목 없음"
             if (query.isBlank()) {
                 binding.scheduleTitleTv.text = title
@@ -206,19 +207,24 @@ class SearchAdapter(
             binding.schedulePinnedIv.visibility = if (schedule.isPinned) View.VISIBLE else View.GONE
             binding.scheduleCheckbox.visibility = View.INVISIBLE
 
+            binding.root.showMode = SwipeLayout.ShowMode.LayDown
+            binding.root.addDrag(SwipeLayout.DragEdge.Left, binding.scheduleLeftBottomWrapper)
+            binding.root.addDrag(SwipeLayout.DragEdge.Right, binding.scheduleRightBottomWrapper)
+            mItemManger.bindView(itemView, bindingAdapterPosition)
+
             binding.schedulePinIv.setOnClickListener {
                 onPinClick(schedule)
-                scheduleTouchHelper.closeSwipedMenu(holder)
+                mItemManger.closeItem(bindingAdapterPosition)
             }
 
             binding.scheduleEditIv.setOnClickListener {
                 onEditClick(schedule)
-                scheduleTouchHelper.closeSwipedMenu(holder)
+                mItemManger.closeItem(bindingAdapterPosition)
             }
 
             binding.scheduleDeleteIv.setOnClickListener {
                 onDeleteClick(schedule)
-                scheduleTouchHelper.closeSwipedMenu(holder)
+                mItemManger.closeItem(bindingAdapterPosition)
             }
         }
 
@@ -254,7 +260,7 @@ class SearchAdapter(
                 localRouteInfo?.arrivalTime?.let(::formatRouteTime)
             )
 
-            return serverRange ?: localRange ?: "계산 중..."
+            return serverRange ?: localRange ?: "계산 중.."
         }
 
         private fun buildRouteDuration(

--- a/app/src/main/java/com/example/pace/ui/main/calendar/SearchFilterBottomSheet.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/SearchFilterBottomSheet.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.example.pace.R
 import com.example.pace.data.viewmodel.ScheduleViewModel
@@ -25,17 +24,8 @@ class SearchFilterBottomSheet : BottomSheetDialogFragment() {
         (requireActivity() as MainActivity).getSharedViewModel()
     }
 
-    private var selectedView: View? = null
 
     // 18가지 색상 리스트
-    private val colorList = listOf(
-        R.color.schedule_1, R.color.schedule_2, R.color.schedule_3,
-        R.color.schedule_4, R.color.schedule_5, R.color.schedule_6,
-        R.color.schedule_7, R.color.schedule_8, R.color.schedule_9,
-        R.color.schedule_10, R.color.schedule_11, R.color.schedule_12,
-        R.color.schedule_13, R.color.schedule_14, R.color.schedule_15,
-        R.color.schedule_16, R.color.schedule_17, R.color.schedule_18
-    )
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -52,10 +42,6 @@ class SearchFilterBottomSheet : BottomSheetDialogFragment() {
         setupColorPalette() // 18개 색상 동적 생성
         setupSwitch()       // 스위치 설정
 
-        binding.btnApply.setOnClickListener {
-            viewModel.searchWithCurrentQuery()
-            dismiss()
-        }
     }
 
     // SearchFilterBottomSheet.kt 수정 제안

--- a/app/src/main/java/com/example/pace/ui/main/calendar/SearchFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/SearchFragment.kt
@@ -15,18 +15,16 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.pace.data.model.Schedule
+import com.example.pace.data.viewmodel.ScheduleViewModel
 import com.example.pace.databinding.FragmentSearchBinding
 import com.example.pace.databinding.LayoutSearchEmptyBinding
-import com.example.pace.ui.main.MainActivity
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
-import androidx.recyclerview.widget.ItemTouchHelper
-import com.example.pace.data.viewmodel.ScheduleViewModel
 import com.example.pace.ui.add_schedule.AddScheduleActivity
+import com.example.pace.ui.main.MainActivity
 import com.example.pace.ui.main.home.DeleteRepeatScheduleDialog
 import com.example.pace.ui.main.home.DeleteScheduleDialog
-import com.example.pace.ui.main.home.ScheduleTouchHelper
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class SearchFragment : Fragment() {
@@ -34,7 +32,6 @@ class SearchFragment : Fragment() {
     private val binding get() = _binding!!
 
     private lateinit var searchAdapter: SearchAdapter
-    private lateinit var scheduleTouchHelper: ScheduleTouchHelper
     private var recyclerView: RecyclerView? = null
 
     private val viewModel: ScheduleViewModel by lazy {
@@ -63,7 +60,6 @@ class SearchFragment : Fragment() {
         binding.etSearch.requestFocus()
         showKeyboard()
 
-        // 툴바 숨기기
         (requireActivity() as MainActivity).binding.mainToolbar.visibility = View.GONE
     }
 
@@ -72,22 +68,17 @@ class SearchFragment : Fragment() {
             context = requireContext(),
             onPinClick = { schedule ->
                 try {
-                    // startDate에서 날짜 정보(yyyy-MM-dd) 추출
                     val dateStr = schedule.startDate.substring(0, 10)
                     val date = java.time.LocalDate.parse(dateStr)
-
-                    // 뷰모델의 로컬 핀 토글 함수 호출 (UI 즉시 반영용)
                     viewModel.togglePinLocally(date, schedule.id)
                     searchAdapter.updateItemPinStatus(schedule.id, !schedule.isPinned)
                 } catch (e: Exception) {
                     android.util.Log.e("SearchPinError", "날짜 파싱 에러: ${e.message}")
                 }
             },
-            // 2. 삭제: 프래그먼트에 정의한 showDeleteDialog 호출
             onDeleteClick = { schedule ->
                 showDeleteDialog(schedule)
             },
-            // 3. 수정: AddScheduleActivity로 이동
             onEditClick = { schedule ->
                 val intent = Intent(requireContext(), AddScheduleActivity::class.java).apply {
                     putExtra("isEdit", true)
@@ -98,7 +89,6 @@ class SearchFragment : Fragment() {
                 }
                 startActivity(intent)
             },
-            // 4. 편집 모드 선택
             onEditSelect = { id ->
                 viewModel.toggleSelection(id)
             }
@@ -111,33 +101,21 @@ class SearchFragment : Fragment() {
             )
             layoutManager = LinearLayoutManager(context)
             adapter = searchAdapter
-
-
         }
-
-        // 스와이프 로직 연결
-        scheduleTouchHelper = ScheduleTouchHelper(searchAdapter)
-        ItemTouchHelper(scheduleTouchHelper).attachToRecyclerView(recyclerView)
-        searchAdapter.scheduleTouchHelper = scheduleTouchHelper
     }
 
     private fun observeSearchResults() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                // 1. 검색 결과 및 편집 모드/선택 상태 통합 관찰
                 launch {
                     viewModel.searchResults.collectLatest { results ->
                         val query = binding.etSearch.text.toString().trim()
-
-                        // 어댑터에 검색어를 먼저 전달 (하이라이트용)
                         searchAdapter.updateQuery(query)
 
                         if (results.isEmpty()) {
                             if (query.isEmpty()) showInitialState() else showEmptyState()
                         } else {
                             val uiItems = transformToSearchItems(results)
-
-                            // [수정] removeAllViews 대신 어댑터 업데이트만 수행
                             binding.searchResultContainer.visibility = View.VISIBLE
                             if (recyclerView?.parent == null) {
                                 binding.searchResultContainer.addView(recyclerView)
@@ -152,14 +130,12 @@ class SearchFragment : Fragment() {
                     }
                 }
 
-                // 2. 선택된 ID 세트 관찰 (편집 모드 체크박스 즉시 반영)
                 launch {
                     viewModel.selectedIds.collect { ids ->
                         searchAdapter.updateSelectedIds(ids)
                     }
                 }
 
-                // 3. 경로 상세 정보 관찰
                 launch {
                     viewModel.routeDetails.collectLatest { routeMap ->
                         searchAdapter.updateRouteInfo(routeMap)
@@ -169,30 +145,14 @@ class SearchFragment : Fragment() {
         }
     }
 
-
-    private fun showResultList(results: List<ScheduleListItem>) {
-        binding.searchResultContainer.removeAllViews()
-        recyclerView?.let { rv ->
-            if (rv.parent == null) {
-                binding.searchResultContainer.addView(rv)
-            } else {
-                binding.searchResultContainer.addView(rv)
-            }
-            searchAdapter.submitList(results)
-            recyclerView?.scrollToPosition(0)
-        }
-    }
-
     private fun setupSearchInput() {
         binding.etSearch.addTextChangedListener { text ->
             val query = text?.toString()?.trim() ?: ""
-            // 어댑터 쿼리 업데이트는 위 observe 로직에서 처리하므로 삭제 가능
 
             if (query.isEmpty()) {
                 viewModel.clearSearch()
                 showInitialState()
             } else {
-                // 뷰모델에서 검색 수행 (검색 결과 flow가 방출됨)
                 viewModel.searchSchedules(query)
             }
         }
@@ -200,6 +160,7 @@ class SearchFragment : Fragment() {
 
     private fun setupButtons() {
         binding.btnBack.setOnClickListener {
+            hideKeyboard()
             parentFragmentManager.popBackStack()
         }
 
@@ -236,32 +197,34 @@ class SearchFragment : Fragment() {
         }, 100)
     }
 
+    private fun hideKeyboard() {
+        if (_binding == null) return
+        binding.etSearch.clearFocus()
+        val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(binding.etSearch.windowToken, 0)
+    }
+
     private fun showDeleteDialog(schedule: Schedule) {
-        // 1. 경로 일정 (ROUTE)
         if (schedule.type == "ROUTE") {
             DeleteScheduleDialog(requireContext()).apply {
                 setOnConfirmListener {
                     viewModel.deleteSchedule(schedule.id, withRoute = true)
                 }
             }.show()
-        }
-        // 2. 반복 일정 여부 체크
-        else if (!schedule.repeatRule.isNullOrEmpty()) {
+        } else if (!schedule.repeatRule.isNullOrEmpty()) {
             DeleteRepeatScheduleDialog(requireContext()).apply {
                 setOnOptionSelectedListener { option ->
                     when (option) {
                         "ONLY_THIS" -> {
-                            // schedule.startDate는 expandSchedules에 의해 해당 회차 날짜로 이미 채워져 있음
                             val occurrenceDate = java.time.LocalDate.parse(schedule.startDate)
                             viewModel.deleteOnlyThisOccurrence(schedule, occurrenceDate)
                         }
+
                         "ALL" -> viewModel.deleteSchedule(schedule.id, withRoute = false)
                     }
                 }
             }.show()
-        }
-        // 3. 일반 단일 일정
-        else {
+        } else {
             DeleteScheduleDialog(requireContext()).apply {
                 setOnConfirmListener {
                     viewModel.deleteSchedule(schedule.id, withRoute = false)
@@ -272,21 +235,14 @@ class SearchFragment : Fragment() {
 
     private fun transformToSearchItems(schedules: List<Schedule>): List<ScheduleListItem> {
         val resultList = mutableListOf<ScheduleListItem>()
-
-        // 1. 날짜별 그룹화 (문자열 처리를 통해 yyyy-MM-dd 형태 추출)
         val grouped = schedules.groupBy { it.startDate.substring(0, 10) }
-
-        // 2. 날짜순 정렬
         val sortedDates = grouped.keys.sorted()
 
         for (dateStr in sortedDates) {
             val date = java.time.LocalDate.parse(dateStr)
-
-            // 리스트 프래그먼트와 동일한 날짜 헤더 추가 (yyyy년 MM월 dd일 (E))
             resultList.add(ScheduleListItem.DateHeader(formatDateToHeader(date)))
 
             grouped[dateStr]?.let { daySchedules ->
-                // 3. 해당 날짜 내 정렬 (리스트 화면과 동일: 고정 -> 종일 -> 시간순)
                 val sortedList = daySchedules.sortedWith(
                     compareBy(
                         { !it.isPinned },
@@ -300,18 +256,17 @@ class SearchFragment : Fragment() {
         return resultList
     }
 
-    // 리스트 프래그먼트와 동일한 포맷 함수 추가
     private fun formatDateToHeader(date: java.time.LocalDate): String {
         return try {
-            val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 (E)", java.util.Locale.KOREAN)
+            val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy년 MM월 dd일(E)", java.util.Locale.KOREAN)
             date.format(formatter)
         } catch (e: Exception) {
             date.toString()
         }
     }
 
-
     override fun onDestroyView() {
+        hideKeyboard()
         super.onDestroyView()
         (requireActivity() as MainActivity).binding.mainToolbar.visibility = View.VISIBLE
         _binding = null

--- a/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
@@ -36,6 +36,8 @@ class HomeFragment: Fragment() {
     private val viewModel: ScheduleViewModel by activityViewModels()
     private lateinit var scheduleAdapter: ScheduleRVAdapter
     private var modalCaseDialog: ModalCaseDialog? = null
+    private var isViewReady = false
+    private var pendingResetToToday = false
 
     // 선택한 날짜 저장 및 불러오기
     private lateinit var spf: SharedPreferences
@@ -61,6 +63,9 @@ class HomeFragment: Fragment() {
         binding.homeAddScheduleLl.setOnClickListener {
             startActivity(Intent(context, AddScheduleActivity::class.java))
         }
+
+        isViewReady = true
+        applyPendingResetIfNeeded()
 
         return binding.root
     }
@@ -293,8 +298,14 @@ class HomeFragment: Fragment() {
     }
 
     fun resetToToday() {
-        if (!isAdded) return
+        if (!isAdded || !isViewReady) {
+            pendingResetToToday = true
+            return
+        }
+        performResetToToday()
+    }
 
+    private fun performResetToToday() {
         selectedDate = LocalDate.now()
         spf.edit().putString("SELECTED_DATE", selectedDate.toString()).apply()
         viewModel.setSelectedDate(selectedDate)
@@ -316,9 +327,16 @@ class HomeFragment: Fragment() {
         filterAndDisplaySchedules()
     }
 
+    private fun applyPendingResetIfNeeded() {
+        if (!pendingResetToToday || !isViewReady) return
+        pendingResetToToday = false
+        performResetToToday()
+    }
+
     override fun onDestroyView() {
         modalCaseDialog?.dismiss()
         modalCaseDialog = null
+        isViewReady = false
         super.onDestroyView()
     }
 

--- a/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
@@ -171,6 +171,7 @@ class RouteFragment : Fragment() {
     private var currentRealtimeParams: List<RealtimeParam>? = null
     private var sessionToken: AutocompleteSessionToken? = null
     private var pendingResetToCurrentLocationState = false
+    private var pendingActionModeExtras: Bundle? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -223,21 +224,13 @@ class RouteFragment : Fragment() {
         setupRouteDetailListeners()
         setupBookmarkHeaderListenrs()
 
-        val activityIntent = requireActivity().intent
-        val actionMode = activityIntent?.getStringExtra("ACTION_MODE")
-        if (actionMode == "SCHEDULE") {
-            startScheduleMode()
-//            activityIntent.removeExtra("ACTION_MODE")
-        } else if(actionMode == "SCHEDULE_ROUTE" || actionMode == "ROUTE_RESEARCH") {
-            startScheduleRouteMode()
-//            activityIntent.removeExtra("ACTION_MODE")
-        }
         hasSchedule = false
 
         routeViewModel.fetchRouteOnlySchedule()
 
         observeRouteViewModel()
         observeSettings()
+        applyPendingActionModeIfNeeded()
         applyPendingResetIfNeeded()
     }
 
@@ -651,11 +644,10 @@ class RouteFragment : Fragment() {
         enterSearchMode()
     }
 
-    fun startScheduleRouteMode() {
+    fun startScheduleRouteMode(intent: android.content.Intent = requireActivity().intent) {
         if (_binding == null || !isAdded || view == null) return
 
         currentEntryMode = EntryMode.SCHEDULE_ROUTE
-        val intent = requireActivity().intent
 
         val nameExtra = intent.getStringExtra("SCHEDULE_NAME")
         scheduleName = if(nameExtra.isNullOrBlank()) "일정명" else nameExtra
@@ -3101,6 +3093,48 @@ class RouteFragment : Fragment() {
         mainActivity?.myLocation?.let {
             currentMyLocation = LatLng(it.latitude, it.longitude)
             moveMapToCurrentLocation(it, animate = false)
+        }
+    }
+
+    fun isInScheduleSelectionMode(): Boolean {
+        return currentEntryMode == EntryMode.SCHEDULE ||
+            currentEntryMode == EntryMode.SCHEDULE_ROUTE
+    }
+
+    fun consumeActionModeIntent(intent: android.content.Intent? = requireActivity().intent): Boolean {
+        if (_binding == null || !isAdded || view == null || intent == null) {
+            if (intent != null) {
+                pendingActionModeExtras = Bundle(intent.extras ?: Bundle())
+            }
+            return false
+        }
+
+        val actionMode = intent.getStringExtra("ACTION_MODE")
+
+        return when (actionMode) {
+            "SCHEDULE" -> {
+                startScheduleMode()
+                intent.removeExtra("ACTION_MODE")
+                requireActivity().intent?.removeExtra("ACTION_MODE")
+                true
+            }
+            "SCHEDULE_ROUTE", "ROUTE_RESEARCH" -> {
+                startScheduleRouteMode(intent)
+                intent.removeExtra("ACTION_MODE")
+                requireActivity().intent?.removeExtra("ACTION_MODE")
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun applyPendingActionModeIfNeeded() {
+        val extras = pendingActionModeExtras ?: return
+        val pendingIntent = android.content.Intent().apply {
+            replaceExtras(Bundle(extras))
+        }
+        if (consumeActionModeIntent(pendingIntent)) {
+            pendingActionModeExtras = null
         }
     }
 

--- a/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/route/RouteFragment.kt
@@ -170,6 +170,7 @@ class RouteFragment : Fragment() {
     private var realtimePollingJob: Job? = null
     private var currentRealtimeParams: List<RealtimeParam>? = null
     private var sessionToken: AutocompleteSessionToken? = null
+    private var pendingResetToCurrentLocationState = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -237,6 +238,7 @@ class RouteFragment : Fragment() {
 
         observeRouteViewModel()
         observeSettings()
+        applyPendingResetIfNeeded()
     }
 
     private fun showDefaultScheduleOverlay(data: RouteOnlyScheduleData? = null) {
@@ -3020,7 +3022,11 @@ class RouteFragment : Fragment() {
     }
 
     fun resetToCurrentLocationState() {
-        if (_binding == null || !isAdded) return
+        if (_binding == null || !isAdded || !::bottomSheetBehavior.isInitialized) {
+            pendingResetToCurrentLocationState = true
+            return
+        }
+        pendingResetToCurrentLocationState = false
 
         hideKeyboard()
         mainBinding?.searchEt?.clearFocus()
@@ -3096,6 +3102,11 @@ class RouteFragment : Fragment() {
             currentMyLocation = LatLng(it.latitude, it.longitude)
             moveMapToCurrentLocation(it, animate = false)
         }
+    }
+
+    private fun applyPendingResetIfNeeded() {
+        if (!pendingResetToCurrentLocationState || _binding == null || !::bottomSheetBehavior.isInitialized) return
+        resetToCurrentLocationState()
     }
 
     private fun moveMapToCurrentLocation(location: android.location.Location, animate: Boolean) {

--- a/app/src/main/res/layout/bottom_sheet_search_filter.xml
+++ b/app/src/main/res/layout/bottom_sheet_search_filter.xml
@@ -1,78 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="172dp"
+    android:background="@drawable/bg_bottom_sheet_rounded"
     android:orientation="vertical"
-    android:paddingBottom="20dp"> <ImageView
-    android:id="@+id/ic_home_indicator"
-    android:layout_width="80dp"
-    android:layout_height="4dp"
-    android:layout_gravity="center_horizontal"
-    android:layout_marginTop="12dp"
-    android:background="@drawable/ic_homeindicator"
-    android:contentDescription="Home indicator" />
+    android:paddingStart="24dp"
+    android:paddingTop="10dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="20dp">
+
+    <View
+        android:id="@+id/ic_home_indicator"
+        android:layout_width="60dp"
+        android:layout_height="5dp"
+        android:layout_gravity="center_horizontal"
+        android:background="@drawable/ic_homeindicator" />
 
     <TextView
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_height="24dp"
+        android:layout_marginTop="24dp"
+        android:gravity="center_vertical"
         android:text="색상"
-        android:layout_marginStart="20dp"
-        android:textSize="20sp"
-        android:textStyle="bold"/> <HorizontalScrollView
+        android:textAppearance="@style/TextAppearance.App.BodyMd.SemiBold"
+        android:textColor="@color/text_primary" />
+
+    <HorizontalScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="44dp"
         android:layout_marginTop="8dp"
         android:scrollbars="none">
 
         <LinearLayout
             android:id="@+id/layout_color_container"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="44dp"
+            android:gravity="bottom"
             android:orientation="horizontal"
             android:paddingStart="20dp"
-            android:paddingEnd="20dp">
-        </LinearLayout>
+            android:paddingEnd="20dp" />
     </HorizontalScrollView>
-
 
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:paddingEnd="20dp">
+        android:layout_marginTop="24dp">
 
         <TextView
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="경로 일정 포함"
-            android:layout_marginStart="20dp"
-            android:textSize="20sp"
+            android:layout_height="24dp"
             android:layout_centerVertical="true"
-            android:textColor="@color/text_primary"/>
+            android:gravity="center_vertical"
+            android:text="경로 일정 포함"
+            android:textAppearance="@style/TextAppearance.App.BodySm.Regular"
+            android:textColor="@color/text_primary" />
 
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/switch_include_route"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="24dp"
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             app:thumbTint="@color/switch_selector"
-            app:trackTint="@color/switch_selector"/>
+            app:trackTint="@color/switch_selector" />
     </RelativeLayout>
-
-    <Button
-        android:id="@+id/btn_apply"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="32dp"
-        android:text="확인"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        android:textColor="@android:color/white"
-        android:backgroundTint="@color/primary_500"
-        app:cornerRadius="12dp" />
-
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_filter_color.xml
+++ b/app/src/main/res/layout/item_filter_color.xml
@@ -1,21 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:padding="8dp">
+    android:layout_width="24dp"
+    android:layout_height="44dp"
+    android:layout_marginEnd="20dp">
 
-    <View
-        android:id="@+id/view_color_circle"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:background="@drawable/circle_schedulecolor"
-        android:backgroundTint="@color/text_primary"/>
+    <FrameLayout
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="bottom|center_horizontal">
 
-    <ImageView
-        android:id="@+id/iv_check"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_gravity="center"
-        android:src="@drawable/ic_check_white"
-        android:visibility="gone" />
+        <View
+            android:id="@+id/view_color_circle"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:background="@drawable/circle_schedulecolor"
+            android:backgroundTint="@color/text_primary" />
+
+        <ImageView
+            android:id="@+id/iv_check"
+            android:layout_width="14dp"
+            android:layout_height="14dp"
+            android:layout_gravity="center"
+            android:src="@drawable/ic_check_white"
+            android:visibility="gone" />
+    </FrameLayout>
+
 </FrameLayout>


### PR DESCRIPTION
- [FEAT]
# PR템플릿 

## 변경 사항 요약
- ROUTE 일정 수정 시 기존 알람/워커를 수정 전 스냅샷 기준으로 먼저 취소한 뒤, 최신 데이터 기준으로 다시 예약하도록 수정
- 메인에 유지되는 5개 프래그먼트의 초기화/리셋 타이밍 보강
- 리스트 프래그먼트 편집 모드에서 고정 상태 아이콘이 정상적으로 보이도록 수정
- 검색 프래그먼트 필터 바텀시트 UI 디자인 반영
- 검색 프래그먼트 RecyclerView 아이템 스와이프 동작을 홈과 동일한 방식으로 반영
- 바텀네비 구조 변경에 맞춰 RouteFragment 진입 시 ACTION_MODE 처리 로직 수정

## 체크리스트
- [v] 코드 빌드 성공
- [v] 에뮬레이터 실행 시 성공

## 사진올리는곳
