### PR TITLE
[Fix]: 홈 화면 스와이프 로직

### DIFF
--- a/app/src/main/java/com/example/pace/data/db/ScheduleDao.kt
+++ b/app/src/main/java/com/example/pace/data/db/ScheduleDao.kt
@@ -92,4 +92,7 @@ interface ScheduleDao {
 
     @Query("UPDATE schedules SET is_pinned = :pinnedStatus WHERE id = :scheduleId")
     suspend fun updatePinStatus(scheduleId: Long, pinnedStatus: Boolean)
+
+    @Query("UPDATE schedules SET pinned_dates = :pinnedDates WHERE id = :scheduleId")
+    suspend fun updatePinnedDates(scheduleId: Long, pinnedDates: String?)
 }

--- a/app/src/main/java/com/example/pace/data/db/ScheduleDatabase.kt
+++ b/app/src/main/java/com/example/pace/data/db/ScheduleDatabase.kt
@@ -11,7 +11,7 @@ import com.example.pace.data.model.UserSettingsEntity // 👈 1. Import 추가
 
 @Database(
     entities = [Schedule::class, UserSettingsEntity::class],
-    version = 15,
+    version = 16,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/pace/data/model/Schedule.kt
+++ b/app/src/main/java/com/example/pace/data/model/Schedule.kt
@@ -95,6 +95,9 @@ data class Schedule(
     @ColumnInfo(name = "is_pinned")
     var isPinned: Boolean = false,
 
+    @ColumnInfo(name = "pinned_dates")
+    val pinnedDates: String? = null,
+
     @ColumnInfo(name = "is_swiped", defaultValue = "0")
     var isSwiped: Boolean = false,
 

--- a/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repository/ScheduleRepository.kt
@@ -83,5 +83,6 @@ interface ScheduleRepository {
 
     suspend fun convertRouteToNormalLocal(scheduleId: Long): Boolean
     suspend fun updatePinStatus(id: Long, isPinned: Boolean)
+    suspend fun updatePinnedDates(id: Long, pinnedDates: String?)
     suspend fun removeLocalRouteSchedule(scheduleId: Long)
 }

--- a/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pace/data/repository/repositoryImpl/ScheduleRepositoryImpl.kt
@@ -210,6 +210,7 @@ class ScheduleRepositoryImpl @Inject constructor(
                             // Provider values stay primary, but app-only flags and overrides are preserved.
                             remote.copy(
                                 isPinned = local.isPinned,
+                                pinnedDates = local.pinnedDates,
                                 isCompleted = local.isCompleted,
                                 isSwiped = local.isSwiped,
 
@@ -871,11 +872,17 @@ class ScheduleRepositoryImpl @Inject constructor(
                                 continue
                             }
 
+                            val pinnedDates = schedule.pinnedDates
+                                ?.split(",")
+                                ?.map { it.trim() }
+                                ?.filter { it.isNotEmpty() }
+                                .orEmpty()
                             expandedList.add(schedule.copy(
                                 startDate = formattedDate,
                                 endDate = occurrenceEndLocalDate.format(dateFormatter),
                                 startTime = if (schedule.isAllDay) "00:00" else schedule.startTime,
-                                endTime = if (schedule.isAllDay) "23:59" else schedule.endTime
+                                endTime = if (schedule.isAllDay) "23:59" else schedule.endTime,
+                                isPinned = formattedDate in pinnedDates
                             ))
                             count++
                         }
@@ -952,6 +959,7 @@ class ScheduleRepositoryImpl @Inject constructor(
             calendarColor = colorInt,
             isCompleted = false,
             isPinned = false,
+            pinnedDates = null,
             isSwiped = false,
             sourceType = "SERVER",
             repeatRule = null,
@@ -1011,6 +1019,7 @@ class ScheduleRepositoryImpl @Inject constructor(
             type = if (isRouteType) "ROUTE" else "NORMAL",
             isCompleted = false,
             isPinned = false,
+            pinnedDates = null,
             isSwiped = false,
             sourceType = "SERVER",
             serverId = this.scheduleId,
@@ -1069,6 +1078,7 @@ class ScheduleRepositoryImpl @Inject constructor(
             withRoute = isRouteType,
             isCompleted = existing?.isCompleted ?: false,
             isPinned = existing?.isPinned ?: false,
+            pinnedDates = existing?.pinnedDates,
             isSwiped = existing?.isSwiped ?: false,
             type = if (isRouteType) "ROUTE" else "NORMAL",
             eventColor = colorInt,
@@ -1426,6 +1436,10 @@ class ScheduleRepositoryImpl @Inject constructor(
 
     override suspend fun updatePinStatus(id: Long, isPinned: Boolean) {
         scheduleDao.updatePinStatus(id, isPinned)
+    }
+
+    override suspend fun updatePinnedDates(id: Long, pinnedDates: String?) {
+        scheduleDao.updatePinnedDates(id, pinnedDates)
     }
 
     override suspend fun removeLocalRouteSchedule(scheduleId: Long) {

--- a/app/src/main/java/com/example/pace/data/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/example/pace/data/viewmodel/RouteViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.pace.data.datasource.AuthDataStore
-import com.example.pace.data.model.MarkScheduleProvider
 import com.example.pace.data.model.request.RouteSearchRequest
 import com.example.pace.data.model.response.RouteOnlyScheduleData
 import com.example.pace.data.model.response.RouteResponse
@@ -56,25 +55,25 @@ class RouteViewModel @Inject constructor(
                     _errorMessage.value = ""
                     _routeResult.value = routes
                 } else {
-                    applyMockRoutes("empty route response")
+                    handleRouteSearchFailure("empty route response")
                 }
             } catch (e: retrofit2.HttpException) {
                 val errorBody = e.response()?.errorBody()?.string()
                 Log.e("RouteApiError", "Route search http error: code=${e.code()}, body=$errorBody")
-                applyMockRoutes("http ${e.code()} - $errorBody")
+                handleRouteSearchFailure("http ${e.code()} - $errorBody")
             } catch (e: Exception) {
                 Log.e("RouteApiError", "Route search exception: ${e.message}", e)
-                applyMockRoutes("exception: ${e.message}")
+                handleRouteSearchFailure("exception: ${e.message}")
             } finally {
                 _isLoading.value = false
             }
         }
     }
 
-    private fun applyMockRoutes(reason: String) {
-        Log.w("RouteApiMock", "Using mock route data because $reason")
-        _errorMessage.value = ""
-        _routeResult.value = MarkScheduleProvider.getMockRouteApiResponse().routeApiResDtoList.orEmpty()
+    private fun handleRouteSearchFailure(reason: String) {
+        Log.w("RouteApi", "Route search fallback suppressed: $reason")
+        _errorMessage.value = reason
+        _routeResult.value = emptyList()
     }
 
     fun fetchRouteOnlySchedule() {

--- a/app/src/main/java/com/example/pace/data/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/example/pace/data/viewmodel/ScheduleViewModel.kt
@@ -1097,18 +1097,44 @@ class ScheduleViewModel @Inject constructor(
         repository.updateExDate(scheduleForExDate)
     }
 
-    fun togglePinLocally(date: LocalDate, scheduleId: Long) {
+    fun togglePinLocally(date: LocalDate, scheduleId: Long, occurrenceDate: String = date.format(dateFormatter)) {
         viewModelScope.launch {
             val currentSchedules = scheduleMap.value[date] ?: return@launch
-            val targetSchedule = currentSchedules.find { it.id == scheduleId } ?: return@launch
+            val targetSchedule = currentSchedules.find {
+                it.id == scheduleId && it.startDate == occurrenceDate
+            } ?: return@launch
 
             val newPinStatus = !targetSchedule.isPinned
 
-            repository.updatePinStatus(scheduleId, newPinStatus)
+            if (!targetSchedule.repeatRule.isNullOrEmpty()) {
+                val pinnedDates = targetSchedule.pinnedDates
+                    ?.split(",")
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotEmpty() }
+                    ?.toMutableSet()
+                    ?: mutableSetOf()
+
+                if (newPinStatus) {
+                    pinnedDates.add(occurrenceDate)
+                } else {
+                    pinnedDates.remove(occurrenceDate)
+                }
+
+                repository.updatePinnedDates(
+                    scheduleId,
+                    pinnedDates.takeIf { it.isNotEmpty() }?.sorted()?.joinToString(",")
+                )
+            } else {
+                repository.updatePinStatus(scheduleId, newPinStatus)
+            }
 
             val updatedMap = scheduleMap.value.toMutableMap()
             val updatedList = currentSchedules.map {
-                if (it.id == scheduleId) it.copy(isPinned = newPinStatus) else it
+                if (it.id == scheduleId && it.startDate == occurrenceDate) {
+                    it.copy(isPinned = newPinStatus)
+                } else {
+                    it
+                }
             }
             updatedMap[date] = updatedList
 

--- a/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/add_schedule/RouteScheduleFragment.kt
@@ -1385,7 +1385,6 @@ class RouteScheduleFragment : Fragment() {
     private fun shouldBlockRouteScheduleCount(routeObject: RouteResponse?): Boolean {
         if (routeObject == null) return false
 
-        currentRouteScheduleCount = 30
         val projectedRouteCount = if (originalIsRouteSchedule) {
             currentRouteScheduleCount
         } else {

--- a/app/src/main/java/com/example/pace/ui/main/calendar/DailyPageAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/DailyPageAdapter.kt
@@ -2,7 +2,9 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListUpdateCallback
 import androidx.recyclerview.widget.RecyclerView
 import com.example.pace.data.model.Schedule
 import com.example.pace.data.model.response.RouteInfo
@@ -25,9 +27,46 @@ class DailyPageAdapter(
     val START_POSITION = Int.MAX_VALUE / 2
 
     fun updateEvents(newEvents: Map<LocalDate, List<Schedule>>, newRouteMap: Map<Long, RouteInfo> = emptyMap()) {
+        val oldEvents = events
+        val oldRouteMap = routeInfoMap
+        val affectedDates = (oldEvents.keys + newEvents.keys).distinct().sorted()
+
+        val diffResult = DiffUtil.calculateDiff(
+            DailyPageDiffCallback(
+                dates = affectedDates,
+                oldEvents = oldEvents,
+                newEvents = newEvents,
+                oldRouteMap = oldRouteMap,
+                newRouteMap = newRouteMap
+            )
+        )
+
         this.events = newEvents
         this.routeInfoMap = newRouteMap
-        notifyDataSetChanged()
+        diffResult.dispatchUpdatesTo(object : ListUpdateCallback {
+            override fun onInserted(position: Int, count: Int) {
+                repeat(count) { index ->
+                    notifyItemChanged(getPosition(affectedDates[position + index]))
+                }
+            }
+
+            override fun onRemoved(position: Int, count: Int) {
+                repeat(count) { index ->
+                    notifyItemChanged(getPosition(affectedDates[position + index]))
+                }
+            }
+
+            override fun onMoved(fromPosition: Int, toPosition: Int) {
+                notifyItemChanged(getPosition(affectedDates[fromPosition]))
+                notifyItemChanged(getPosition(affectedDates[toPosition]))
+            }
+
+            override fun onChanged(position: Int, count: Int, payload: Any?) {
+                repeat(count) { index ->
+                    notifyItemChanged(getPosition(affectedDates[position + index]), payload)
+                }
+            }
+        })
     }
 
     fun getDate(position: Int): LocalDate = LocalDate.now().plusDays((position - START_POSITION).toLong())
@@ -81,4 +120,38 @@ class DailyPageAdapter(
     }
 
     override fun getItemCount(): Int = Int.MAX_VALUE
+
+    private class DailyPageDiffCallback(
+        private val dates: List<LocalDate>,
+        private val oldEvents: Map<LocalDate, List<Schedule>>,
+        private val newEvents: Map<LocalDate, List<Schedule>>,
+        private val oldRouteMap: Map<Long, RouteInfo>,
+        private val newRouteMap: Map<Long, RouteInfo>
+    ) : DiffUtil.Callback() {
+
+        override fun getOldListSize(): Int = dates.size
+
+        override fun getNewListSize(): Int = dates.size
+
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return dates[oldItemPosition] == dates[newItemPosition]
+        }
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val date = dates[oldItemPosition]
+            val oldSchedules = oldEvents[date].orEmpty().sortedWith(
+                compareBy({ !it.isPinned }, { !it.isAllDay }, { it.startTime })
+            )
+            val newSchedules = newEvents[date].orEmpty().sortedWith(
+                compareBy({ !it.isPinned }, { !it.isAllDay }, { it.startTime })
+            )
+
+            if (oldSchedules != newSchedules) return false
+
+            val scheduleIds = (oldSchedules + newSchedules).map { it.id }.distinct()
+            return scheduleIds.all { scheduleId ->
+                oldRouteMap[scheduleId] == newRouteMap[scheduleId]
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListFragment.kt
@@ -182,7 +182,7 @@ class ScheduleListFragment : Fragment() {
             onPinClick = { schedule ->
                 try {
                     val date = LocalDate.parse(schedule.startDate.substring(0, 10))
-                    viewModel.togglePinLocally(date, schedule.id)
+                    viewModel.togglePinLocally(date, schedule.id, schedule.startDate)
                 } catch (_: Exception) {
                 }
             },

--- a/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListRVAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/ScheduleListRVAdapter.kt
@@ -50,6 +50,7 @@ class ScheduleListRVAdapter(
     }
 
     fun updateData(newItems: List<ScheduleListItem>, newRouteMap: Map<Long, RouteInfo> = emptyMap()) {
+        mItemManger.closeAllItems()
         val diffResult = DiffUtil.calculateDiff(
             ScheduleListDiffCallback(
                 oldItems = items,
@@ -191,6 +192,7 @@ class ScheduleListRVAdapter(
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(schedule: Schedule) {
+            binding.root.close(false)
             binding.scheduleViewTop.translationX = 0f
             binding.root.setSwipeEnabled(!isEditMode)
 

--- a/app/src/main/java/com/example/pace/ui/main/calendar/SearchAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/SearchAdapter.kt
@@ -46,9 +46,13 @@ class SearchAdapter(
         private const val TYPE_SCHEDULE_ITEM = 1
     }
 
-    fun updateItemPinStatus(scheduleId: Long, isPinned: Boolean) {
+    fun updateItemPinStatus(scheduleId: Long, occurrenceDate: String, isPinned: Boolean) {
         val updatedItems = items.map { item ->
-            if (item is ScheduleListItem.ScheduleItem && item.schedule.id == scheduleId) {
+            if (
+                item is ScheduleListItem.ScheduleItem &&
+                item.schedule.id == scheduleId &&
+                item.schedule.startDate == occurrenceDate
+            ) {
                 item.copy(schedule = item.schedule.copy(isPinned = isPinned))
             } else {
                 item

--- a/app/src/main/java/com/example/pace/ui/main/calendar/SearchFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/calendar/SearchFragment.kt
@@ -72,8 +72,8 @@ class SearchFragment : Fragment() {
                 try {
                     val dateStr = schedule.startDate.substring(0, 10)
                     val date = java.time.LocalDate.parse(dateStr)
-                    viewModel.togglePinLocally(date, schedule.id)
-                    searchAdapter.updateItemPinStatus(schedule.id, !schedule.isPinned)
+                    viewModel.togglePinLocally(date, schedule.id, schedule.startDate)
+                    searchAdapter.updateItemPinStatus(schedule.id, schedule.startDate, !schedule.isPinned)
                 } catch (e: Exception) {
                     android.util.Log.e("SearchPinError", "날짜 파싱 에러: ${e.message}")
                 }

--- a/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/HomeFragment.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.LinearSnapHelper
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SimpleItemAnimator
 import com.example.pace.data.model.Schedule
 import com.example.pace.databinding.FragmentHomeBinding
 import com.example.pace.ui.add_schedule.AddScheduleActivity
@@ -35,9 +36,11 @@ class HomeFragment: Fragment() {
     lateinit var binding: FragmentHomeBinding
     private val viewModel: ScheduleViewModel by activityViewModels()
     private lateinit var scheduleAdapter: ScheduleRVAdapter
+    private var scheduleItemAnimator: RecyclerView.ItemAnimator? = null
     private var modalCaseDialog: ModalCaseDialog? = null
     private var isViewReady = false
     private var pendingResetToToday = false
+    private var lastRenderedScheduleDate: LocalDate? = null
 
     // 선택한 날짜 저장 및 불러오기
     private lateinit var spf: SharedPreferences
@@ -76,11 +79,13 @@ class HomeFragment: Fragment() {
             // 로컬 데이터만 가공하는 함수를 호출하세요.
             Log.d("PinClick", "클릭된 일정: ${schedule.title}, 현재 핀 상태: ${schedule.isPinned}")
 
-            viewModel.togglePinLocally(selectedDate, schedule.id)
+            viewModel.togglePinLocally(selectedDate, schedule.id, schedule.startDate)
             Log.d("PinClick", "클릭된 일정: ${schedule.title}, 나중 핀 상태: ${schedule.isPinned}")
         }
 
         binding.homeScheduleRv.adapter = scheduleAdapter
+        scheduleItemAnimator = binding.homeScheduleRv.itemAnimator
+        (scheduleItemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
         scheduleAdapter.setMyOnClickListener(object: ScheduleRVAdapter.MyOnClickListener{
             override fun showModalCase(scheduleList: List<Schedule>, position: Int) {
                 modalCaseDialog?.dismiss()
@@ -279,7 +284,22 @@ class HomeFragment: Fragment() {
             )
         )
 
+        val shouldSuppressAnimation =
+            lastRenderedScheduleDate != null && lastRenderedScheduleDate != selectedDate
+        if (shouldSuppressAnimation) {
+            binding.homeScheduleRv.itemAnimator = null
+        }
+
         scheduleAdapter.updateData(sortedList, viewModel.routeDetails.value)
+        lastRenderedScheduleDate = selectedDate
+
+        if (shouldSuppressAnimation) {
+            binding.homeScheduleRv.post {
+                if (!isAdded || !isViewReady) return@post
+                binding.homeScheduleRv.itemAnimator = scheduleItemAnimator
+                (binding.homeScheduleRv.itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
+            }
+        }
 
         // UI 처리
         if(sortedList.isEmpty()){
@@ -307,6 +327,7 @@ class HomeFragment: Fragment() {
 
     private fun performResetToToday() {
         selectedDate = LocalDate.now()
+        lastRenderedScheduleDate = null
         spf.edit().putString("SELECTED_DATE", selectedDate.toString()).apply()
         viewModel.setSelectedDate(selectedDate)
 

--- a/app/src/main/java/com/example/pace/ui/main/home/ScheduleRVAdapter.kt
+++ b/app/src/main/java/com/example/pace/ui/main/home/ScheduleRVAdapter.kt
@@ -1,15 +1,16 @@
 package com.example.pace.ui.main.home
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.daimajia.swipe.SwipeLayout
 import com.daimajia.swipe.adapters.RecyclerSwipeAdapter
+import com.daimajia.swipe.util.Attributes
 import com.example.pace.R
 import com.example.pace.data.model.Schedule
 import com.example.pace.data.model.response.RouteInfo
@@ -18,7 +19,7 @@ import com.example.pace.ui.RouteCalculator
 import com.google.gson.Gson
 
 class ScheduleRVAdapter(
-    private var scheduleList: MutableList<Schedule>,
+    private var scheduleList: List<Schedule>,
     private val context: Context,
     private val onPinClick: (Schedule) -> Unit,
 ) : RecyclerSwipeAdapter<ScheduleRVAdapter.ViewHolder>() {
@@ -39,12 +40,27 @@ class ScheduleRVAdapter(
         mOnClickListener = myOnClickListener
     }
 
-    @SuppressLint("NotifyDataSetChanged")
     fun updateData(newSchedules: List<Schedule>, newRouteMap: Map<Long, RouteInfo> = emptyMap()) {
+        resetSwipeState()
+        val diffResult = DiffUtil.calculateDiff(
+            ScheduleDiffCallback(
+                oldItems = scheduleList,
+                newItems = newSchedules,
+                oldRouteMap = routeInfoMap,
+                newRouteMap = newRouteMap
+            )
+        )
         routeInfoMap = newRouteMap
-        scheduleList.clear()
-        scheduleList.addAll(newSchedules)
-        notifyDataSetChanged()
+        scheduleList = newSchedules.toList()
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    private fun resetSwipeState() {
+        mItemManger.getOpenLayouts().toList().forEach { layout ->
+            layout.close(false, false)
+            mItemManger.removeShownLayouts(layout)
+        }
+        setMode(Attributes.Mode.Single)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -90,8 +106,34 @@ class ScheduleRVAdapter(
 
     override fun getSwipeLayoutResourceId(position: Int): Int = R.id.item_schedule
 
+    private class ScheduleDiffCallback(
+        private val oldItems: List<Schedule>,
+        private val newItems: List<Schedule>,
+        private val oldRouteMap: Map<Long, RouteInfo>,
+        private val newRouteMap: Map<Long, RouteInfo>
+    ) : DiffUtil.Callback() {
+
+        override fun getOldListSize(): Int = oldItems.size
+
+        override fun getNewListSize(): Int = newItems.size
+
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldItems[oldItemPosition]
+            val newItem = newItems[newItemPosition]
+            return oldItem.id == newItem.id && oldItem.startDate == newItem.startDate
+        }
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val oldItem = oldItems[oldItemPosition]
+            val newItem = newItems[newItemPosition]
+            if (oldItem != newItem) return false
+            return oldRouteMap[oldItem.id] == newRouteMap[newItem.id]
+        }
+    }
+
     inner class ViewHolder(val binding: ItemScheduleBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(schedule: Schedule) {
+            binding.root.close(false)
             binding.scheduleCheckbox.visibility = View.GONE
             binding.scheduleTitleTv.text = schedule.title ?: "제목 없음"
 


### PR DESCRIPTION
- [FEAT]
# PR템플릿 

## 변경 사항 요약
- 홈 화면을 diffutil 방식의 리사이클러뷰로 변경
- 날짜를 옮길 때는 diffutil의 애니메이션 잠시 끄기
- 날짜를 옮길 때 position의 스와이프 상태 닫기 (강화된 로직)
- 스케줄 데이터 모델에 고정된 스케줄 날짜를 추가하여 반복일정에서도 핀이 중복으로 나오던 오류 수정
- 캘린더 페이지 프래그먼트의 바텀시트 리사이클러뷰도 diffutil로 변경

## 체크리스트
- [v] 코드 빌드 성공
- [v] 에뮬레이터 실행 시 성공

## 사진올리는곳
